### PR TITLE
Fix GeneralMeasurement bundle count assertion

### DIFF
--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/PHR-Client/medmij-ggz-phr-1-1-retrieve.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/PHR-Client/medmij-ggz-phr-1-1-retrieve.xml
@@ -1812,9 +1812,9 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
-            <description value="Confirm that the returned searchset Bundle contains 14 Observation resource(s). "/>
+            <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
-            <expression value="Bundle.entry.where(resource.is(Observation)).count() = 14"/>
+            <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
             <warningOnly value="false"/>
          </assert>
       </action>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
@@ -2845,9 +2845,9 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
-            <description value="Confirm that the returned searchset Bundle contains 14 Observation resource(s). "/>
+            <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
-            <expression value="Bundle.entry.where(resource.is(Observation)).count() = 14"/>
+            <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
             <warningOnly value="false"/>
          </assert>
       </action>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
@@ -2845,9 +2845,9 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
-            <description value="Confirm that the returned searchset Bundle contains 14 Observation resource(s). "/>
+            <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
-            <expression value="Bundle.entry.where(resource.is(Observation)).count() = 14"/>
+            <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
             <warningOnly value="false"/>
          </assert>
       </action>


### PR DESCRIPTION
As mentioned in [MM-1952](https://bits.nictiz.nl/browse/MM-1952) – GeneralMeasurements Observation Total Assertion Test fails unfairly on counting 14 Observations.
Only 1 Observation is expected in the GeneralMeasurements implementation. 
TODO: create new Assert for testing existence of 14 subcomponents