### PR TITLE
MM-2879: Deleted .subscriberId from bgz-coverage-ts-02

### DIFF
--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/_reference/resources/medmij-bgz-coverage-ts-02.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/_reference/resources/medmij-bgz-coverage-ts-02.xml
@@ -36,7 +36,6 @@
       <reference value="Patient/medmij-bgz-patient-ts-01"/>
       <display value="Johan XXX_Helleman"/>
    </subscriber>
-   <subscriberId value="12345678"/>
    <beneficiary>
       <reference value="Patient/medmij-bgz-patient-ts-01"/>
       <display value="Johan XXX_Helleman"/>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/_reference/resources/medmij-bgz-coverage-ts-02.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/_reference/resources/medmij-bgz-coverage-ts-02.xml
@@ -36,7 +36,6 @@
       <reference value="Patient/medmij-bgz-patient-ts-01"/>
       <display value="Johan XXX_Helleman"/>
    </subscriber>
-   <subscriberId value="12345678"/>
    <beneficiary>
       <reference value="Patient/medmij-bgz-patient-ts-01"/>
       <display value="Johan XXX_Helleman"/>

--- a/src/BgZ-3-0/Cert/_reference/resources/medmij-bgz-coverage-ts-02.xml
+++ b/src/BgZ-3-0/Cert/_reference/resources/medmij-bgz-coverage-ts-02.xml
@@ -36,7 +36,6 @@
       <reference value="Patient/medmij-bgz-patient-ts-01"/>
       <display value="Johan XXX_Helleman"/>
    </subscriber>
-   <subscriberId value="12345678"/>
    <beneficiary>
       <reference value="Patient/medmij-bgz-patient-ts-01"/>
       <display value="Johan XXX_Helleman"/>


### PR DESCRIPTION
Deleted the .subscriberId element from "medmij-bgz-coverage-ts-02" fixture in the cert folder from the respective src and dev folders

Standard: BgZ 3.0
Folders: .../src/BgZ3-0/Cert and  .../dev/FHIR3-0-2-MM20200101-Cert/BgZ-3-0