### PR TITLE
MM 3045: Add XIS check to confirm that query parameters in the search URL are present in the self link

### DIFF
--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Cert/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-2-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-2-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-4-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-4-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-5-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-5-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-6-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-6-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-6-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-6-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-7-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-7-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-7-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-7-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-8-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-8-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-8-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-0-8-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2a-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2a-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2a-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2a-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2b-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2b-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2b-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-2b-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-4-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-1-4-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-10-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-4-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-4-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-5-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-2-5-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-4-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-3-4-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-4-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-4-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-4-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-4-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-10-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-10-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-10-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-10-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-11-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-11-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-11-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-11-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-12-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-12-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-12-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-12-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-13-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-13-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-13-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-13-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-14-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-14-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-14-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-14-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-15-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-15-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-15-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-15-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-4-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-4-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-5-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-5-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-6-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-6-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-6-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-6-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-7-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-7-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-7-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-7-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-8-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-8-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-8-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-8-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-9-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-9-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-9-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-6-9-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-7-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-8-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-8-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-8-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/Agreement/mp9-ma-xis-8-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-2-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-2-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-4-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-4-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-5-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-0-5-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-1-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-1-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-1-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-1-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-10-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-2-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-1-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-1-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-7-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1a-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1a-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1a-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1a-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1b-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1b-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1b-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1b-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1c-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1c-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1c-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-1c-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-2-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-2-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-3-json.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Medication-9-0-7-test/XIS-Server/DispenseRequest/mp9-vv-xis-9-3-xml.xml
@@ -70,7 +70,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -146,7 +146,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -130,7 +130,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM201901-Test/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -88,7 +88,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
@@ -50,7 +50,7 @@
                <code value="search"/>
             </type>
             <resource value="AllergyIntolerance"/>
-            <description value="Test PHR client to retrieve AllergyIntolerance resources."/>
+            <description value="Test XIS server to serve AllergyIntolerance resources."/>
             <accept value="xml"/>
             <destination value="1"/>
             <origin value="1"/>
@@ -63,39 +63,6 @@
                <value value="${UUID}"/>
             </requestHeader>
          </operation>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that HTTP header Authorization contains the patient token ${patient-token-id}"/>
-            <direction value="request"/>
-            <headerField value="Authorization"/>
-            <value value="${patient-token-id}"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that query parameter 'patient=' was not present to avoid BSNs in the URL."/>
-            <direction value="request"/>
-            <operator value="notContains"/>
-            <requestURL value="patient="/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that query parameter 'subject=' was not present to avoid BSNs in the URL."/>
-            <direction value="request"/>
-            <operator value="notContains"/>
-            <requestURL value="subject="/>
-         </assert>
       </action>
       <action>
          <assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestScript xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-   <id value="aic-xis-1-3-serve-allergyintolerance"/>
+   <id value="aic-xis-1-3-serve-allergyintolerance-json"/>
    <meta>
       <profile value="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript"/>
    </meta>
-   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-3-serve-allergyintolerance"/>
+   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-3-serve-allergyintolerance-json"/>
    <version value="stu3-2.0- patchlevel 2022-03"/>
-   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.3 - Serve 0 AllergyIntolerance resources"/>
+   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.3 - Serve 0 AllergyIntolerance resources - JSON Format"/>
    <status value="active"/>
    <publisher value="Nictiz"/>
    <contact>
@@ -32,18 +32,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
-   <fixture id="patient-token-fixture">
-      <resource>
-         <reference value="../../_reference/allergyintolerance-nl-core-patient-XXX-Daalen-token.xml"/>
-      </resource>
-   </fixture>
    <profile id="Bundle-profile">
       <reference value="http://hl7.org/fhir/StructureDefinition/Bundle"/>
    </profile>
    <variable>
       <name value="patient-token-id"/>
-      <expression value="Patient.id"/>
-      <sourceId value="patient-token-fixture"/>
+      <defaultValue value="Bearer 8c6e2d90-f0f7-11e9-aaef-0800200c9a66"/>
+      <description value="OAuth Token for current patient"/>
    </variable>
    <test id="scenario1-2-serve-allergyintolerance">
       <name value="Scenario 1.3"/>
@@ -56,6 +51,7 @@
             </type>
             <resource value="AllergyIntolerance"/>
             <description value="Test XIS server to serve AllergyIntolerance resources."/>
+            <accept value="json"/>
             <destination value="1"/>
             <origin value="1"/>
             <requestHeader>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestScript xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-   <id value="aic-xis-1-1-serve-allergyintolerance-json"/>
+   <id value="aic-xis-1-3-serve-allergyintolerance-xml"/>
    <meta>
       <profile value="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript"/>
    </meta>
-   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-1-serve-allergyintolerance-json"/>
+   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-3-serve-allergyintolerance-xml"/>
    <version value="stu3-2.0- patchlevel 2022-03"/>
-   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.1 - Serve AllergyIntolerance resources - JSON Format"/>
+   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.3 - Serve 0 AllergyIntolerance resources - XML Format"/>
    <status value="active"/>
    <publisher value="Nictiz"/>
    <contact>
@@ -17,7 +17,7 @@
          <use value="work"/>
       </telecom>
    </contact>
-   <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of XXX-Stalewska."/>
+   <description value="Scenario 1.3 - Serve all AllergyIntolerance resources of XXX-Daalen."/>
    <origin>
       <index value="1"/>
       <profile>
@@ -37,12 +37,12 @@
    </profile>
    <variable>
       <name value="patient-token-id"/>
-      <defaultValue value="Bearer 3daef240-ee84-11e9-aaef-0800200c9a66"/>
+      <defaultValue value="Bearer 8c6e2d90-f0f7-11e9-aaef-0800200c9a66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
-   <test id="scenario1-1-serve-allergyintolerance">
-      <name value="Scenario 1.1"/>
-      <description value="Serve all AllergyIntolerance resources of XXX-Stalewska."/>
+   <test id="scenario1-2-serve-allergyintolerance">
+      <name value="Scenario 1.3"/>
+      <description value="Serve no AllergyIntolerance resources of XXX-Daalen."/>
       <action>
          <operation>
             <type>
@@ -51,7 +51,7 @@
             </type>
             <resource value="AllergyIntolerance"/>
             <description value="Test XIS server to serve AllergyIntolerance resources."/>
-            <accept value="json"/>
+            <accept value="xml"/>
             <destination value="1"/>
             <origin value="1"/>
             <requestHeader>
@@ -242,10 +242,20 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
-            <description value="Confirm that the response Bundle contains 4 AllergyIntolerance resource(s). "/>
+            <description value="Confirm that the response Bundle contains 0 AllergyIntolerance resource(s). "/>
             <direction value="response"/>
-            <expression value="Bundle.entry.where(resource.is(AllergyIntolerance)).count() = 4"/>
+            <expression value="Bundle.entry.where(resource.is(AllergyIntolerance)).count() = 0"/>
             <warningOnly value="false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
+            <direction value="response"/>
+            <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
          </assert>
       </action>
    </test>

--- a/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2294,7 +2294,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2503,7 +2503,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2712,7 +2712,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2922,7 +2922,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3154,7 +3154,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3386,7 +3386,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3618,7 +3618,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3850,7 +3850,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4071,7 +4071,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4292,7 +4292,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4513,7 +4513,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4734,7 +4734,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4966,7 +4966,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5187,7 +5187,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5408,7 +5408,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5628,7 +5628,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5838,7 +5838,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -6059,7 +6059,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 93cde269-ce35-4077-a39d-19296670e949"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 2"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2991,6 +3095,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationStatement resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationStatement)).count() = 1"/>
@@ -3205,6 +3320,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3433,6 +3559,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationDispense resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationDispense)).count() = 1"/>
@@ -3647,6 +3784,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3875,6 +4023,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Immunization resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Immunization)).count() = 1"/>
@@ -4078,6 +4237,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4295,6 +4465,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4505,6 +4686,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4708,6 +4900,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4936,6 +5139,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Procedure resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Procedure)).count() = 2"/>
@@ -5146,6 +5360,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Encounter resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Encounter)).count() = 1"/>
@@ -5349,6 +5574,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5775,6 +6011,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Appointment resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Appointment)).count() = 1"/>
@@ -5978,6 +6225,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2294,7 +2294,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2503,7 +2503,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2712,7 +2712,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2922,7 +2922,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3154,7 +3154,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3386,7 +3386,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3618,7 +3618,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3850,7 +3850,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4071,7 +4071,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4292,7 +4292,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4513,7 +4513,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4734,7 +4734,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4966,7 +4966,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5187,7 +5187,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5408,7 +5408,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5628,7 +5628,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5838,7 +5838,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -6059,7 +6059,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 93cde269-ce35-4077-a39d-19296670e949"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 2"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2991,6 +3095,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationStatement resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationStatement)).count() = 1"/>
@@ -3205,6 +3320,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3433,6 +3559,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationDispense resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationDispense)).count() = 1"/>
@@ -3647,6 +3784,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3875,6 +4023,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Immunization resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Immunization)).count() = 1"/>
@@ -4078,6 +4237,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4295,6 +4465,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4505,6 +4686,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4708,6 +4900,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4936,6 +5139,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Procedure resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Procedure)).count() = 2"/>
@@ -5146,6 +5360,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Encounter resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Encounter)).count() = 1"/>
@@ -5349,6 +5574,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5775,6 +6011,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Appointment resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Appointment)).count() = 1"/>
@@ -5978,6 +6225,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2263,7 +2263,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2471,7 +2471,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2679,7 +2679,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2888,7 +2888,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3108,7 +3108,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3328,7 +3328,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3548,7 +3548,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3768,7 +3768,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3988,7 +3988,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4208,7 +4208,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4428,7 +4428,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4648,7 +4648,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4868,7 +4868,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5088,7 +5088,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5308,7 +5308,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5527,7 +5527,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5736,7 +5736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5956,7 +5956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6056a9eb-da6a-45dc-b557-e854e138af8f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2957,6 +3061,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3159,6 +3274,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3375,6 +3501,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3577,6 +3714,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3793,6 +3941,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3995,6 +4154,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4211,6 +4381,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4413,6 +4594,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4629,6 +4821,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4831,6 +5034,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5047,6 +5261,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5249,6 +5474,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5673,6 +5909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5875,6 +6122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2263,7 +2263,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2471,7 +2471,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2679,7 +2679,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2888,7 +2888,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3108,7 +3108,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3328,7 +3328,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3548,7 +3548,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3768,7 +3768,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3988,7 +3988,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4208,7 +4208,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4428,7 +4428,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4648,7 +4648,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4868,7 +4868,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5088,7 +5088,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5308,7 +5308,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5527,7 +5527,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5736,7 +5736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5956,7 +5956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6056a9eb-da6a-45dc-b557-e854e138af8f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2957,6 +3061,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3159,6 +3274,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3375,6 +3501,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3577,6 +3714,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3793,6 +3941,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3995,6 +4154,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4211,6 +4381,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4413,6 +4594,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4629,6 +4821,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4831,6 +5034,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5047,6 +5261,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5249,6 +5474,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5673,6 +5909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5875,6 +6122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/BgZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2295,7 +2295,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2516,7 +2516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2737,7 +2737,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2958,7 +2958,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3179,7 +3179,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3399,7 +3399,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3608,7 +3608,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3818,7 +3818,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6fc70c51-bdda-422e-9eaa-899fe24c4ef9"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 1"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11291000146105. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11291000146105').exists()).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11341000146107. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11341000146107').exists()).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 228366006. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='228366006').exists()).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365980008. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365980008').exists()).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2364,6 +2468,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365470003. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365470003').exists()).count() = 1"/>
@@ -2567,6 +2682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2784,6 +2910,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 CarePlan resource(s) that contains category.coding.code = 243114000. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as CarePlan).where(category.coding.code.where($this='243114000').exists()).count() = 1"/>
@@ -2994,6 +3131,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 3 Observation resource(s) that contains category.coding.code = 49581000146104. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(category.coding.code.where($this='49581000146104').exists()).count() = 3"/>
@@ -3197,6 +3345,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3825,6 +3984,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2295,7 +2295,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2516,7 +2516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2737,7 +2737,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2958,7 +2958,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3179,7 +3179,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3399,7 +3399,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3608,7 +3608,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3818,7 +3818,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6fc70c51-bdda-422e-9eaa-899fe24c4ef9"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 1"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11291000146105. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11291000146105').exists()).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11341000146107. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11341000146107').exists()).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 228366006. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='228366006').exists()).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365980008. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365980008').exists()).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2364,6 +2468,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365470003. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365470003').exists()).count() = 1"/>
@@ -2567,6 +2682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2784,6 +2910,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 CarePlan resource(s) that contains category.coding.code = 243114000. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as CarePlan).where(category.coding.code.where($this='243114000').exists()).count() = 1"/>
@@ -2994,6 +3131,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 3 Observation resource(s) that contains category.coding.code = 49581000146104. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(category.coding.code.where($this='49581000146104').exists()).count() = 3"/>
@@ -3197,6 +3345,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3825,6 +3984,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 55180ef6-52b9-4ce2-954f-7f623b568bef"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2333,6 +2437,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2535,6 +2650,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2751,6 +2877,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2960,6 +3097,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3162,6 +3310,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3787,6 +3946,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2264,7 +2264,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2484,7 +2484,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2704,7 +2704,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2924,7 +2924,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3144,7 +3144,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3363,7 +3363,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3571,7 +3571,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3780,7 +3780,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 55180ef6-52b9-4ce2-954f-7f623b568bef"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2333,6 +2437,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2535,6 +2650,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2751,6 +2877,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2960,6 +3097,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3162,6 +3310,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3787,6 +3946,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2264,7 +2264,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2484,7 +2484,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2704,7 +2704,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2924,7 +2924,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3144,7 +3144,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3363,7 +3363,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3571,7 +3571,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3780,7 +3780,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/GGZ-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-allergyintolerance">
       <name value="Scenario 1.1 - Serve AllergyIntolerance"/>
       <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-allergyintolerance">
       <name value="Scenario 1.1 - Serve AllergyIntolerance"/>
       <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-composition">
       <name value="Scenario 1.1 - Serve Composition"/>
       <description value="Scenario 1.1 - Serve all Composition resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-composition">
       <name value="Scenario 1.1 - Serve Composition"/>
       <description value="Scenario 1.1 - Serve all Composition resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-medicationrequest">
       <name value="Scenario 1.1 - Serve MedicationRequest"/>
       <description value="Scenario 1.1 - Serve all MedicationRequest resources of person 1."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-medicationrequest">
       <name value="Scenario 1.1 - Serve MedicationRequest"/>
       <description value="Scenario 1.1 - Serve all MedicationRequest resources of person 1."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-lab-and-diagnostic-observation">
       <name value="Scenario 1.1 - Serve Lab and Diagnostic Observations"/>
       <description value="Scenario 1.1 - Serve all Lab and Diagnostic Observations resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-lab-and-diagnostic-observation">
       <name value="Scenario 1.1 - Serve Lab and Diagnostic Observations"/>
       <description value="Scenario 1.1 - Serve all Lab and Diagnostic Observations resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-patient">
       <name value="Scenario 1.1 - Serve Patient"/>
       <description value="Scenario 1.1 - Serve Patient resource of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-patient">
       <name value="Scenario 1.1 - Serve Patient"/>
       <description value="Scenario 1.1 - Serve Patient resource of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/GenPractData-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/PHR-Client/medmij-images-phr-1-1-send-one-image.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/PHR-Client/medmij-images-phr-1-1-send-one-image.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/PHR-Client/medmij-images-phr-1-2-send-collection-images.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/PHR-Client/medmij-images-phr-1-2-send-collection-images.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 14bc6cc6-7b7b-4c29-b662-c5284d76cf3c"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="lab-Scenarioset1-1">
       <name value="Scenario 1.1"/>
       <description value="Scenario 1.1 - Query All LaboratoryResults of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 14bc6cc6-7b7b-4c29-b662-c5284d76cf3c"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="lab-Scenarioset1-1">
       <name value="Scenario 1.1"/>
       <description value="Scenario 1.1 - Query All LaboratoryResults of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/LaboratoryResults-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
@@ -124,7 +124,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -202,7 +202,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-2-2-retrieve-1-documentreference.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-2-2-retrieve-1-documentreference.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-1-send-1-document.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-1-send-1-document.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-2-send-2-documents.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-2-send-2-documents.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/PDFA-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.1-ServeTask">
       <name value="Scenario1.1 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.1-ServeTask">
       <name value="Scenario1.1 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.2-ServeTask">
       <name value="Scenario1.2 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.2-ServeTask">
       <name value="Scenario1.2 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.3-ServeTask">
       <name value="Scenario1.3 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.3-ServeTask">
       <name value="Scenario1.3 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.4-ServeTask">
       <name value="Scenario1.4 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.4-ServeTask">
       <name value="Scenario1.4 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.5-ServeTask">
       <name value="Scenario1.5 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire reference in this Task is assumed to be invalid."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.5-ServeTask">
       <name value="Scenario1.5 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire reference in this Task is assumed to be invalid."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.6-ServeTask">
       <name value="Scenario1.6 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire referenced in this Task is assumed to be too complex to render for the client."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.6-ServeTask">
       <name value="Scenario1.6 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire referenced in this Task is assumed to be too complex to render for the client."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/Questionnaires-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-1-send-most-recent-bodyweight.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-1-send-most-recent-bodyweight.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-2-send-bloodpressures-from-period.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-2-send-bloodpressures-from-period.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-3-send-observations-from-period.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-3-send-observations-from-period.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-all-bloodpressure">
       <name value="Scenario 1.1"/>
       <description value="Serve all BloodPressure Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-all-bloodpressure">
       <name value="Scenario 1.1"/>
       <description value="Serve all BloodPressure Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-latest-bodyweight">
       <name value="Scenario 1.2"/>
       <description value="Serve latest bodyweight Observation resource"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-latest-bodyweight">
       <name value="Scenario 1.2"/>
       <description value="Serve latest bodyweight Observation resource"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-3-serve-all-bloodglucose">
       <name value="Scenario 1.3"/>
       <description value="Serve all BloodGlucose Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-3-serve-all-bloodglucose">
       <name value="Scenario 1.3"/>
       <description value="Serve all BloodGlucose Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-all-heartrate">
       <name value="Scenario 1.4"/>
       <description value="Serve all HeartRate Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-all-heartrate">
       <name value="Scenario 1.4"/>
       <description value="Serve all HeartRate Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-5-serve-period-bloodpressure">
       <name value="Scenario 1.5"/>
       <description value="Serve BloodPressure Observation resources in a period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-5-serve-period-bloodpressure">
       <name value="Scenario 1.5"/>
       <description value="Serve BloodPressure Observation resources in a period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-6-serve-period-observation">
       <name value="Scenario 1.6"/>
       <description value="Serve multiple type of Observation resources in period T-30 - T-0"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-6-serve-period-observation">
       <name value="Scenario 1.6"/>
       <description value="Serve multiple type of Observation resources in period T-30 - T-0"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-7-serve-all-vitalsign-observation">
       <name value="Scenario 1.7"/>
       <description value="Serve all VitalSign Observation resources"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-7-serve-all-vitalsign-observation">
       <name value="Scenario 1.7"/>
       <description value="Serve all VitalSign Observation resources"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/SelfMeasurements-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.1"/>
       <description value="Serve Appointment resources of XXX-Verweij in a period from T-150 and everything in the future."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.1"/>
       <description value="Serve Appointment resources of XXX-Verweij in a period from T-150 and everything in the future."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.2"/>
       <description value="Serve Appointment resources of XXX-Zalentein in a one month period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.2"/>
       <description value="Serve Appointment resources of XXX-Zalentein in a one month period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.3"/>
       <description value="Serve Appointment resources of XXX-Egmond in a one year period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.3"/>
       <description value="Serve Appointment resources of XXX-Egmond in a one year period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Cert/eAppointment-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-json.xml
@@ -50,7 +50,7 @@
                <code value="search"/>
             </type>
             <resource value="AllergyIntolerance"/>
-            <description value="Test PHR client to retrieve AllergyIntolerance resources."/>
+            <description value="Test XIS server to serve AllergyIntolerance resources."/>
             <accept value="json"/>
             <destination value="1"/>
             <origin value="1"/>
@@ -63,39 +63,6 @@
                <value value="${UUID}"/>
             </requestHeader>
          </operation>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that HTTP header Authorization contains the patient token ${patient-token-id}"/>
-            <direction value="request"/>
-            <headerField value="Authorization"/>
-            <value value="${patient-token-id}"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that query parameter 'patient=' was not present to avoid BSNs in the URL."/>
-            <direction value="request"/>
-            <operator value="notContains"/>
-            <requestURL value="patient="/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that query parameter 'subject=' was not present to avoid BSNs in the URL."/>
-            <direction value="request"/>
-            <operator value="notContains"/>
-            <requestURL value="subject="/>
-         </assert>
       </action>
       <action>
          <assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
@@ -50,7 +50,7 @@
                <code value="search"/>
             </type>
             <resource value="AllergyIntolerance"/>
-            <description value="Test PHR client to retrieve AllergyIntolerance resources."/>
+            <description value="Test XIS server to serve AllergyIntolerance resources."/>
             <accept value="xml"/>
             <destination value="1"/>
             <origin value="1"/>
@@ -63,39 +63,6 @@
                <value value="${UUID}"/>
             </requestHeader>
          </operation>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that HTTP header Authorization contains the patient token ${patient-token-id}"/>
-            <direction value="request"/>
-            <headerField value="Authorization"/>
-            <value value="${patient-token-id}"/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that query parameter 'patient=' was not present to avoid BSNs in the URL."/>
-            <direction value="request"/>
-            <operator value="notContains"/>
-            <requestURL value="patient="/>
-         </assert>
-      </action>
-      <action>
-         <assert>
-            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
-               <valueBoolean value="false"/>
-            </extension>
-            <description value="Confirm that query parameter 'subject=' was not present to avoid BSNs in the URL."/>
-            <direction value="request"/>
-            <operator value="notContains"/>
-            <requestURL value="subject="/>
-         </assert>
       </action>
       <action>
          <assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-json.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestScript xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-   <id value="aic-xis-1-3-serve-allergyintolerance"/>
+   <id value="aic-xis-1-3-serve-allergyintolerance-json"/>
    <meta>
       <profile value="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript"/>
    </meta>
-   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-3-serve-allergyintolerance"/>
+   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-3-serve-allergyintolerance-json"/>
    <version value="stu3-2.0- patchlevel 2022-03"/>
-   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.3 - Serve 0 AllergyIntolerance resources"/>
+   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.3 - Serve 0 AllergyIntolerance resources - JSON Format"/>
    <status value="active"/>
    <publisher value="Nictiz"/>
    <contact>
@@ -32,18 +32,13 @@
          <code value="FHIR-Server"/>
       </profile>
    </destination>
-   <fixture id="patient-token-fixture">
-      <resource>
-         <reference value="../../_reference/allergyintolerance-nl-core-patient-XXX-Daalen-token.xml"/>
-      </resource>
-   </fixture>
    <profile id="Bundle-profile">
       <reference value="http://hl7.org/fhir/StructureDefinition/Bundle"/>
    </profile>
    <variable>
       <name value="patient-token-id"/>
-      <expression value="Patient.id"/>
-      <sourceId value="patient-token-fixture"/>
+      <defaultValue value="Bearer 8c6e2d90-f0f7-11e9-aaef-0800200c9a66"/>
+      <description value="OAuth Token for current patient"/>
    </variable>
    <test id="scenario1-2-serve-allergyintolerance">
       <name value="Scenario 1.3"/>
@@ -56,6 +51,7 @@
             </type>
             <resource value="AllergyIntolerance"/>
             <description value="Test XIS server to serve AllergyIntolerance resources."/>
+            <accept value="json"/>
             <destination value="1"/>
             <origin value="1"/>
             <requestHeader>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TestScript xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-   <id value="aic-xis-1-1-serve-allergyintolerance-json"/>
+   <id value="aic-xis-1-3-serve-allergyintolerance-xml"/>
    <meta>
       <profile value="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript"/>
    </meta>
-   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-1-serve-allergyintolerance-json"/>
+   <url value="http://nictiz.nl/fhir/TestScript/aic-xis-1-3-serve-allergyintolerance-xml"/>
    <version value="stu3-2.0- patchlevel 2022-03"/>
-   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.1 - Serve AllergyIntolerance resources - JSON Format"/>
+   <name value="MedMij AllergyIntoleranceConversion - XIS Server - Scenario 1.3 - Serve 0 AllergyIntolerance resources - XML Format"/>
    <status value="active"/>
    <publisher value="Nictiz"/>
    <contact>
@@ -17,7 +17,7 @@
          <use value="work"/>
       </telecom>
    </contact>
-   <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of XXX-Stalewska."/>
+   <description value="Scenario 1.3 - Serve all AllergyIntolerance resources of XXX-Daalen."/>
    <origin>
       <index value="1"/>
       <profile>
@@ -37,12 +37,12 @@
    </profile>
    <variable>
       <name value="patient-token-id"/>
-      <defaultValue value="Bearer 3daef240-ee84-11e9-aaef-0800200c9a66"/>
+      <defaultValue value="Bearer 8c6e2d90-f0f7-11e9-aaef-0800200c9a66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
-   <test id="scenario1-1-serve-allergyintolerance">
-      <name value="Scenario 1.1"/>
-      <description value="Serve all AllergyIntolerance resources of XXX-Stalewska."/>
+   <test id="scenario1-2-serve-allergyintolerance">
+      <name value="Scenario 1.3"/>
+      <description value="Serve no AllergyIntolerance resources of XXX-Daalen."/>
       <action>
          <operation>
             <type>
@@ -51,7 +51,7 @@
             </type>
             <resource value="AllergyIntolerance"/>
             <description value="Test XIS server to serve AllergyIntolerance resources."/>
-            <accept value="json"/>
+            <accept value="xml"/>
             <destination value="1"/>
             <origin value="1"/>
             <requestHeader>
@@ -242,10 +242,20 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
-            <description value="Confirm that the response Bundle contains 4 AllergyIntolerance resource(s). "/>
+            <description value="Confirm that the response Bundle contains 0 AllergyIntolerance resource(s). "/>
             <direction value="response"/>
-            <expression value="Bundle.entry.where(resource.is(AllergyIntolerance)).count() = 4"/>
+            <expression value="Bundle.entry.where(resource.is(AllergyIntolerance)).count() = 0"/>
             <warningOnly value="false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
+            <direction value="response"/>
+            <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
          </assert>
       </action>
    </test>

--- a/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/AllergyIntolerance-3-0/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2294,7 +2294,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2503,7 +2503,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2712,7 +2712,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2922,7 +2922,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3154,7 +3154,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3386,7 +3386,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3618,7 +3618,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3850,7 +3850,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4071,7 +4071,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4292,7 +4292,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4513,7 +4513,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4734,7 +4734,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4966,7 +4966,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5187,7 +5187,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5408,7 +5408,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5628,7 +5628,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5838,7 +5838,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -6059,7 +6059,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 93cde269-ce35-4077-a39d-19296670e949"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 2"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2991,6 +3095,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationStatement resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationStatement)).count() = 1"/>
@@ -3205,6 +3320,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3433,6 +3559,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationDispense resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationDispense)).count() = 1"/>
@@ -3647,6 +3784,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3875,6 +4023,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Immunization resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Immunization)).count() = 1"/>
@@ -4078,6 +4237,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4295,6 +4465,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4505,6 +4686,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4708,6 +4900,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4936,6 +5139,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Procedure resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Procedure)).count() = 2"/>
@@ -5146,6 +5360,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Encounter resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Encounter)).count() = 1"/>
@@ -5349,6 +5574,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5775,6 +6011,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Appointment resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Appointment)).count() = 1"/>
@@ -5978,6 +6225,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2294,7 +2294,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2503,7 +2503,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2712,7 +2712,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2922,7 +2922,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3154,7 +3154,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3386,7 +3386,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3618,7 +3618,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3850,7 +3850,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4071,7 +4071,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4292,7 +4292,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4513,7 +4513,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4734,7 +4734,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4966,7 +4966,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5187,7 +5187,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5408,7 +5408,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5628,7 +5628,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5838,7 +5838,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -6059,7 +6059,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 93cde269-ce35-4077-a39d-19296670e949"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 2"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2991,6 +3095,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationStatement resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationStatement)).count() = 1"/>
@@ -3205,6 +3320,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3433,6 +3559,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 MedicationDispense resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationDispense)).count() = 1"/>
@@ -3647,6 +3784,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3875,6 +4023,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Immunization resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Immunization)).count() = 1"/>
@@ -4078,6 +4237,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4295,6 +4465,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4505,6 +4686,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4708,6 +4900,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4936,6 +5139,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Procedure resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Procedure)).count() = 2"/>
@@ -5146,6 +5360,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Encounter resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Encounter)).count() = 1"/>
@@ -5349,6 +5574,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5775,6 +6011,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Appointment resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Appointment)).count() = 1"/>
@@ -5978,6 +6225,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2263,7 +2263,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2471,7 +2471,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2679,7 +2679,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2888,7 +2888,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3108,7 +3108,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3328,7 +3328,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3548,7 +3548,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3768,7 +3768,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3988,7 +3988,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4208,7 +4208,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4428,7 +4428,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4648,7 +4648,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4868,7 +4868,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5088,7 +5088,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5308,7 +5308,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5527,7 +5527,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5736,7 +5736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5956,7 +5956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6056a9eb-da6a-45dc-b557-e854e138af8f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2957,6 +3061,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3159,6 +3274,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3375,6 +3501,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3577,6 +3714,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3793,6 +3941,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3995,6 +4154,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4211,6 +4381,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4413,6 +4594,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4629,6 +4821,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4831,6 +5034,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5047,6 +5261,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5249,6 +5474,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5673,6 +5909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5875,6 +6122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2263,7 +2263,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2471,7 +2471,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2679,7 +2679,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2888,7 +2888,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3108,7 +3108,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3328,7 +3328,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3548,7 +3548,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3768,7 +3768,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3988,7 +3988,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4208,7 +4208,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4428,7 +4428,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4648,7 +4648,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4868,7 +4868,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5088,7 +5088,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5308,7 +5308,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5527,7 +5527,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5736,7 +5736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5956,7 +5956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/XIS-Server/medmij-bgz-xis-1-2-serve-bgz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6056a9eb-da6a-45dc-b557-e854e138af8f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2957,6 +3061,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3159,6 +3274,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3375,6 +3501,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3577,6 +3714,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3793,6 +3941,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3995,6 +4154,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4211,6 +4381,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4413,6 +4594,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4629,6 +4821,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4831,6 +5034,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5047,6 +5261,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5249,6 +5474,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5673,6 +5909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5875,6 +6122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f5b23d59-14ab-4386-9d67-a78cc656a557"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 2"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2991,6 +3095,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 MedicationStatement resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationStatement)).count() = 2"/>
@@ -3205,6 +3320,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3433,6 +3559,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 3 MedicationDispense resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationDispense)).count() = 3"/>
@@ -3647,6 +3784,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3875,6 +4023,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 4 Immunization resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Immunization)).count() = 4"/>
@@ -4078,6 +4237,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4295,6 +4465,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4505,6 +4686,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4708,6 +4900,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4936,6 +5139,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Procedure resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Procedure)).count() = 5"/>
@@ -5146,6 +5360,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Encounter resource(s). Set to warningOnly because of https://bits.nictiz.nl/browse/MM-1497."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Encounter)).count() = 2"/>
@@ -5349,6 +5574,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5775,6 +6011,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Appointment resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Appointment)).count() = 1"/>
@@ -5978,6 +6225,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2294,7 +2294,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2503,7 +2503,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2712,7 +2712,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2922,7 +2922,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3154,7 +3154,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3386,7 +3386,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3618,7 +3618,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3850,7 +3850,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4071,7 +4071,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4292,7 +4292,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4513,7 +4513,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4734,7 +4734,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4966,7 +4966,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5187,7 +5187,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5408,7 +5408,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5628,7 +5628,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5838,7 +5838,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -6059,7 +6059,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f5b23d59-14ab-4386-9d67-a78cc656a557"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 2"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2991,6 +3095,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 MedicationStatement resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationStatement)).count() = 2"/>
@@ -3205,6 +3320,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3433,6 +3559,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 3 MedicationDispense resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(MedicationDispense)).count() = 3"/>
@@ -3647,6 +3784,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3875,6 +4023,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 4 Immunization resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Immunization)).count() = 4"/>
@@ -4078,6 +4237,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4295,6 +4465,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4505,6 +4686,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 1"/>
@@ -4708,6 +4900,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4936,6 +5139,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Procedure resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Procedure)).count() = 5"/>
@@ -5146,6 +5360,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 Encounter resource(s). Set to warningOnly because of https://bits.nictiz.nl/browse/MM-1497."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Encounter)).count() = 2"/>
@@ -5349,6 +5574,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5775,6 +6011,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Appointment resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Appointment)).count() = 1"/>
@@ -5978,6 +6225,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2294,7 +2294,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2503,7 +2503,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2712,7 +2712,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2922,7 +2922,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3154,7 +3154,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3386,7 +3386,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3618,7 +3618,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3850,7 +3850,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4071,7 +4071,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4292,7 +4292,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4513,7 +4513,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4734,7 +4734,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4966,7 +4966,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5187,7 +5187,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5408,7 +5408,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5628,7 +5628,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5838,7 +5838,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -6059,7 +6059,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2263,7 +2263,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2471,7 +2471,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2679,7 +2679,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2888,7 +2888,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3108,7 +3108,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3328,7 +3328,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3548,7 +3548,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3768,7 +3768,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3988,7 +3988,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4208,7 +4208,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4428,7 +4428,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4648,7 +4648,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4868,7 +4868,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5088,7 +5088,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5308,7 +5308,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5527,7 +5527,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5736,7 +5736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5956,7 +5956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6056a9eb-da6a-45dc-b557-e854e138af8f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.5 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2957,6 +3061,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3159,6 +3274,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3375,6 +3501,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3577,6 +3714,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3793,6 +3941,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3995,6 +4154,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4211,6 +4381,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4413,6 +4594,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4629,6 +4821,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4831,6 +5034,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5047,6 +5261,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5249,6 +5474,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5673,6 +5909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5875,6 +6122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2263,7 +2263,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2471,7 +2471,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2679,7 +2679,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2888,7 +2888,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3108,7 +3108,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3328,7 +3328,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3548,7 +3548,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3768,7 +3768,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3988,7 +3988,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4208,7 +4208,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4428,7 +4428,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4648,7 +4648,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -4868,7 +4868,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5088,7 +5088,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5308,7 +5308,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5527,7 +5527,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5736,7 +5736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -5956,7 +5956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6056a9eb-da6a-45dc-b557-e854e138af8f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.5 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2957,6 +3061,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3159,6 +3274,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3375,6 +3501,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3577,6 +3714,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3793,6 +3941,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3995,6 +4154,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4211,6 +4381,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4413,6 +4594,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -4629,6 +4821,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -4831,6 +5034,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5047,6 +5261,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5249,6 +5474,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -5673,6 +5909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -5875,6 +6122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/BgZ-extended-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2295,7 +2295,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2516,7 +2516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2737,7 +2737,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2958,7 +2958,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3179,7 +3179,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3399,7 +3399,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3608,7 +3608,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3818,7 +3818,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6fc70c51-bdda-422e-9eaa-899fe24c4ef9"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 1"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11291000146105. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11291000146105').exists()).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11341000146107. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11341000146107').exists()).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 228366006. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='228366006').exists()).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365980008. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365980008').exists()).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2364,6 +2468,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365470003. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365470003').exists()).count() = 1"/>
@@ -2567,6 +2682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2784,6 +2910,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 CarePlan resource(s) that contains category.coding.code = 243114000. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as CarePlan).where(category.coding.code.where($this='243114000').exists()).count() = 1"/>
@@ -2994,6 +3131,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 3 Observation resource(s) that contains category.coding.code = 49581000146104. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(category.coding.code.where($this='49581000146104').exists()).count() = 3"/>
@@ -3197,6 +3345,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3825,6 +3984,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -539,7 +539,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -760,7 +760,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -981,7 +981,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1201,7 +1201,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1411,7 +1411,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1632,7 +1632,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1853,7 +1853,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2074,7 +2074,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2295,7 +2295,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2516,7 +2516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2737,7 +2737,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2958,7 +2958,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3179,7 +3179,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3399,7 +3399,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3608,7 +3608,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3818,7 +3818,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-1-serve-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 6fc70c51-bdda-422e-9eaa-899fe24c4ef9"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Coverage resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Coverage)).count() = 1"/>
@@ -685,6 +712,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11291000146105. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11291000146105').exists()).count() = 1"/>
@@ -895,6 +933,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Consent resource(s) that contains category.coding.code = 11341000146107. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Consent).where(category.coding.code.where($this='11341000146107').exists()).count() = 1"/>
@@ -1098,6 +1147,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1524,6 +1584,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 228366006. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='228366006').exists()).count() = 1"/>
@@ -1727,6 +1798,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1944,6 +2026,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365980008. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365980008').exists()).count() = 1"/>
@@ -2147,6 +2240,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2364,6 +2468,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 Observation resource(s) that contains code.coding.code = 365470003. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(code.coding.code.where($this='365470003').exists()).count() = 1"/>
@@ -2567,6 +2682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2784,6 +2910,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 1 CarePlan resource(s) that contains category.coding.code = 243114000. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as CarePlan).where(category.coding.code.where($this='243114000').exists()).count() = 1"/>
@@ -2994,6 +3131,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 3 Observation resource(s) that contains category.coding.code = 49581000146104. "/>
             <direction value="response"/>
             <expression value="Bundle.entry.select(resource as Observation).where(category.coding.code.where($this='49581000146104').exists()).count() = 3"/>
@@ -3197,6 +3345,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3825,6 +3984,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 55180ef6-52b9-4ce2-954f-7f623b568bef"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2333,6 +2437,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2535,6 +2650,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2751,6 +2877,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2960,6 +3097,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3162,6 +3310,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3787,6 +3946,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2264,7 +2264,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2484,7 +2484,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2704,7 +2704,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2924,7 +2924,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3144,7 +3144,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3363,7 +3363,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3571,7 +3571,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3780,7 +3780,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 55180ef6-52b9-4ce2-954f-7f623b568bef"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -871,6 +909,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1073,6 +1122,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1497,6 +1557,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1699,6 +1770,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1915,6 +1997,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2117,6 +2210,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2333,6 +2437,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2535,6 +2650,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -2751,6 +2877,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -2960,6 +3097,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -3162,6 +3310,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -3787,6 +3946,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/XIS-Server/medmij-ggz-xis-1-2-serve-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -736,7 +736,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -956,7 +956,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1175,7 +1175,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1384,7 +1384,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1604,7 +1604,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1824,7 +1824,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2044,7 +2044,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2264,7 +2264,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2484,7 +2484,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2704,7 +2704,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -2924,7 +2924,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3144,7 +3144,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3363,7 +3363,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3571,7 +3571,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -3780,7 +3780,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/GGZ-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-allergyintolerance">
       <name value="Scenario 1.1 - Serve AllergyIntolerance"/>
       <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-allergyintolerance">
       <name value="Scenario 1.1 - Serve AllergyIntolerance"/>
       <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-composition">
       <name value="Scenario 1.1 - Serve Composition"/>
       <description value="Scenario 1.1 - Serve all Composition resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-composition">
       <name value="Scenario 1.1 - Serve Composition"/>
       <description value="Scenario 1.1 - Serve all Composition resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-composition-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-medicationrequest">
       <name value="Scenario 1.1 - Serve MedicationRequest"/>
       <description value="Scenario 1.1 - Serve all MedicationRequest resources of person 1."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-medicationrequest">
       <name value="Scenario 1.1 - Serve MedicationRequest"/>
       <description value="Scenario 1.1 - Serve all MedicationRequest resources of person 1."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-json.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare-xml.xml
@@ -69,7 +69,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-lab-and-diagnostic-observation">
       <name value="Scenario 1.1 - Serve Lab and Diagnostic Observations"/>
       <description value="Scenario 1.1 - Serve all Lab and Diagnostic Observations resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-lab-and-diagnostic-observation">
       <name value="Scenario 1.1 - Serve Lab and Diagnostic Observations"/>
       <description value="Scenario 1.1 - Serve all Lab and Diagnostic Observations resources of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-patient">
       <name value="Scenario 1.1 - Serve Patient"/>
       <description value="Scenario 1.1 - Serve Patient resource of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 0aed465d-aab0-4417-9b3c-e6f635892fea"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-patient">
       <name value="Scenario 1.1 - Serve Patient"/>
       <description value="Scenario 1.1 - Serve Patient resource of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/XIS-Server/medmij-gpdata-xis-1-1-serve-patient-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/GenPractData-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/Images-2-0/PHR-Client/medmij-images-phr-1-1-send-one-image.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Images-2-0/PHR-Client/medmij-images-phr-1-1-send-one-image.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Images-2-0/PHR-Client/medmij-images-phr-1-2-send-collection-images.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Images-2-0/PHR-Client/medmij-images-phr-1-2-send-collection-images.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-1-receive-one-image-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Images-2-0/XIS-Server/medmij-images-xis-1-2-receive-collection-images-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 14bc6cc6-7b7b-4c29-b662-c5284d76cf3c"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="lab-Scenarioset1-1">
       <name value="Scenario 1.1"/>
       <description value="Scenario 1.1 - Query All LaboratoryResults of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer 14bc6cc6-7b7b-4c29-b662-c5284d76cf3c"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="lab-Scenarioset1-1">
       <name value="Scenario 1.1"/>
       <description value="Scenario 1.1 - Query All LaboratoryResults of person 1."/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/LaboratoryResults-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-1-3-retrieve-2-binary.xml
@@ -124,7 +124,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -202,7 +202,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-2-2-retrieve-1-documentreference.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-2-2-retrieve-1-documentreference.xml
@@ -104,7 +104,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-1-send-1-document.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-1-send-1-document.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-2-send-2-documents.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/PHR-Client/medmij-pdfa-phr-3-2-send-2-documents.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server-Nictiz-intern/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer f92b6141-55db-46d5-a3ae-874b69907d22"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-3-documentreference">
       <name value="Scenario 1.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-0-documentreference">
       <name value="Scenario 1.2"/>
       <description value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-json.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -55,6 +55,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[1].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-DocumentReference">
       <name value="Scenario 1.4"/>
       <description value="Serve DocumentReference resources"/>
@@ -252,6 +257,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa-xml.xml
@@ -91,7 +91,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -333,7 +333,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -380,7 +380,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-1-serve-1-documentreference">
       <name value="Scenario 2.1"/>
       <description value="Serve all current DocumentReference resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer aae7b5aa-d796-4fba-b4d3-852d9043ee66"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-2-serve-1-DocumentManifest">
       <name value="Scenario 2.2"/>
       <description value="Serve all current DocumentManifest resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-3-serve-1-DocumentManifest">
       <name value="Scenario 2.3"/>
       <description value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-json.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -51,6 +51,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference.startsWith('DocumentReference/'),             Bundle.link.where(relation='self').url.replaceMatches('DocumentManifest[/?].*$','') + Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference,             Bundle.entry.select(resource as DocumentManifest)[0].content[0].p.reference)"/>
       <sourceId value="documentmanifest-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario2-4-serve-documentmanifest">
       <name value="Scenario 2.4 - DocumentManifest"/>
       <description value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
@@ -248,6 +253,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference-xml.xml
@@ -87,7 +87,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -318,7 +318,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-json.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -49,6 +49,11 @@
       <expression value="iif(Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url.startsWith('Binary/'),             Bundle.link.url.replaceMatches('DocumentReference[/?].*$','') + Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url,             Bundle.entry.select(resource as DocumentReference)[0].content[0].attachment.url)"/>
       <sourceId value="documentreference-search-response"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <rule id="assertPDFOrBinary">
       <resource>
          <reference value="../_reference/rule/assertPDFOrBinary.groovy"/>
@@ -251,6 +256,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa-xml.xml
@@ -90,7 +90,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -322,7 +322,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-1-receive-1-document-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/XIS-Server/medmij-pdfa-xis-3-2-receive-2-documents-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/PDFA-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-1_2-1_3-1.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-2_2-2_3-2.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-3_2-3_3-3.xml
@@ -352,7 +352,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-5_2-5.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/PHR-Client/medmij-questionnaires-phr-1-6_2-6.xml
@@ -271,7 +271,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -81,6 +81,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -312,6 +317,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -151,7 +151,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -135,7 +135,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server-Nictiz-intern/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -65,6 +65,11 @@
       <expression value="Task.id"/>
       <sourceId value="task-requested-fixture"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <setup>
       <action>
          <operation>
@@ -296,6 +301,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.1-ServeTask">
       <name value="Scenario1.1 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-json.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.1-ServeTask">
       <name value="Scenario1.1 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-1_3-1-xml.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.2-ServeTask">
       <name value="Scenario1.2 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-json.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.2-ServeTask">
       <name value="Scenario1.2 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-2_3-2-xml.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.3-ServeTask">
       <name value="Scenario1.3 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-json.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -71,6 +71,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.3-ServeTask">
       <name value="Scenario1.3 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -270,6 +275,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-3_3-3-xml.xml
@@ -109,7 +109,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.4-ServeTask">
       <name value="Scenario1.4 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-json.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.4-ServeTask">
       <name value="Scenario1.4 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-4_3-4-xml.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.5-ServeTask">
       <name value="Scenario1.5 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire reference in this Task is assumed to be invalid."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-json.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.5-ServeTask">
       <name value="Scenario1.5 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire reference in this Task is assumed to be invalid."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-5_2-5-xml.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-json.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.6-ServeTask">
       <name value="Scenario1.6 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire referenced in this Task is assumed to be too complex to render for the client."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -93,7 +93,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/XIS-Server/medmij-questionnaires-xis-1-6_2-6-xml.xml
@@ -55,6 +55,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="Scenario1.6-ServeTask">
       <name value="Scenario1.6 - Serve QuestionnaireProvisioningTask for patient 3"/>
       <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire referenced in this Task is assumed to be too complex to render for the client."/>
@@ -254,6 +259,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/Questionnaires-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-1-send-most-recent-bodyweight.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-1-send-most-recent-bodyweight.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-2-send-bloodpressures-from-period.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-2-send-bloodpressures-from-period.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-3-send-observations-from-period.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/PHR-Client/selfmeasurements-phr-2-3-send-observations-from-period.xml
@@ -339,7 +339,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-all-bloodpressure">
       <name value="Scenario 1.1"/>
       <description value="Serve all BloodPressure Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-1-serve-all-bloodpressure">
       <name value="Scenario 1.1"/>
       <description value="Serve all BloodPressure Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-latest-bodyweight">
       <name value="Scenario 1.2"/>
       <description value="Serve latest bodyweight Observation resource"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-2-serve-latest-bodyweight">
       <name value="Scenario 1.2"/>
       <description value="Serve latest bodyweight Observation resource"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-3-serve-all-bloodglucose">
       <name value="Scenario 1.3"/>
       <description value="Serve all BloodGlucose Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-3-serve-all-bloodglucose">
       <name value="Scenario 1.3"/>
       <description value="Serve all BloodGlucose Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-all-heartrate">
       <name value="Scenario 1.4"/>
       <description value="Serve all HeartRate Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer d9f8d61b-c236-489f-aba5-b3bebd312c30"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-4-serve-all-heartrate">
       <name value="Scenario 1.4"/>
       <description value="Serve all HeartRate Observation resources"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-5-serve-period-bloodpressure">
       <name value="Scenario 1.5"/>
       <description value="Serve BloodPressure Observation resources in a period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-5-serve-period-bloodpressure">
       <name value="Scenario 1.5"/>
       <description value="Serve BloodPressure Observation resources in a period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-6-serve-period-observation">
       <name value="Scenario 1.6"/>
       <description value="Serve multiple type of Observation resources in period T-30 - T-0"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-6-serve-period-observation">
       <name value="Scenario 1.6"/>
       <description value="Serve multiple type of Observation resources in period T-30 - T-0"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-7-serve-all-vitalsign-observation">
       <name value="Scenario 1.7"/>
       <description value="Serve all VitalSign Observation resources"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="scenario1-7-serve-all-vitalsign-observation">
       <name value="Scenario 1.7"/>
       <description value="Serve all VitalSign Observation resources"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-1-receive-most-recent-bodyweight-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-2-receive-bloodpressures-from-period-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-json.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/XIS-Server/selfmeasurements-xis-2-3-receive-observations-from-period-xml.xml
@@ -84,7 +84,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/SelfMeasurements-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.1"/>
       <description value="Serve Appointment resources of XXX-Verweij in a period from T-150 and everything in the future."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-1-serve-future-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.1"/>
       <description value="Serve Appointment resources of XXX-Verweij in a period from T-150 and everything in the future."/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.2"/>
       <description value="Serve Appointment resources of XXX-Zalentein in a one month period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.2"/>
       <description value="Serve Appointment resources of XXX-Zalentein in a one month period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-2-serve-month-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-json.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.3"/>
       <description value="Serve Appointment resources of XXX-Egmond in a one year period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
@@ -80,7 +80,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/XIS-Server/medmij-eappt-xis-1-3-serve-year-xml.xml
@@ -45,6 +45,11 @@
       <defaultValue value="${CURRENTDATE}"/>
       <description value="Date that data and queries are expected to be relative to."/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-appointment">
       <name value="Scenario 1.3"/>
       <description value="Serve Appointment resources of XXX-Egmond in a one year period"/>
@@ -241,6 +246,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202001-Test/eAppointment-2-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 2"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 2"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 1"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 1"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202002-Cert/BgLZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 2"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 2 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 2"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server-Nictiz-intern/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 1"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -307,7 +307,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -528,7 +528,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -748,7 +748,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -957,7 +957,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1167,7 +1167,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1387,7 +1387,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1597,7 +1597,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1829,7 +1829,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-1-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer ce28d649-a3ba-4d9c-99e6-d31f6a70476f"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.1 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -464,6 +480,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 Consent resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Consent)).count() = 1"/>
@@ -667,6 +694,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1302,6 +1340,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 5 Observation resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(Observation)).count() = 5"/>
@@ -1721,6 +1770,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the response Bundle contains 1 CarePlan resource(s). "/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(CarePlan)).count() = 1"/>
@@ -1935,6 +1995,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-json.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -40,6 +40,11 @@
       <defaultValue value="Bearer e097ff15-c3a7-43a7-a190-70750e0be2c7"/>
       <description value="OAuth Token for current patient"/>
    </variable>
+   <rule id="assert_response_queryParamsInSelfLink">
+      <resource>
+         <reference value="../_reference/rules/assert_response_queryParamsInSelfLink.groovy"/>
+      </resource>
+   </rule>
    <test id="01-serve-Patient">
       <name value="Scenario 1.2 - Patient"/>
       <description value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
@@ -236,6 +241,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -453,6 +469,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -655,6 +682,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>
@@ -1287,6 +1325,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1704,6 +1753,17 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="false"/>
             </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
             <description value="Confirm that the returned searchset Bundle contains 0 entries or an OperationOutcome."/>
             <direction value="response"/>
             <expression value="Bundle.entry.where(resource.is(OperationOutcome).not()).count() = 0"/>
@@ -1906,6 +1966,17 @@
             <description value="Confirm that Bundle does not use Burgerservicenummer (BSN) in the self link."/>
             <direction value="response"/>
             <expression value="Bundle.link.url.contains('http://fhir.nl/fhir/NamingSystem/bsn') = false"/>
+         </assert>
+      </action>
+      <action>
+         <assert>
+            <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
+               <valueBoolean value="false"/>
+            </extension>
+            <rule>
+               <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
          </assert>
       </action>
       <action>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/XIS-Server/medmij-bglz-xis-1-2-serve-bglz-xml.xml
@@ -75,7 +75,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -296,7 +296,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -516,7 +516,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -735,7 +735,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -943,7 +943,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1152,7 +1152,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1371,7 +1371,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1580,7 +1580,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>
@@ -1800,7 +1800,7 @@
             <extension url="http://touchstone.aegis.net/touchstone/fhir/testing/StructureDefinition/testscript-assert-stopTestOnFail">
                <valueBoolean value="true"/>
             </extension>
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
          </assert>

--- a/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/dev/FHIR3-0-2-MM202002-Test/BgLZ-3-0/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances.xml
+++ b/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-1-serve-allergyintolerances.xml
@@ -12,8 +12,7 @@
   <test id="scenario1-1-retrieve-allergyintolerance">
     <name value="Scenario 1.1"/>
     <description value="Serve all AllergyIntolerance resources of XXX-TEST-D."/>
-    <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-    <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+    <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
     <nts:include value="assert.response.numResources" scope="common" 
       resource="AllergyIntolerance" count="7"/>
   </test>

--- a/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances.xml
+++ b/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntolerance20/medmij-allergyintolerance20-xis-1-2-serve-0-allergyintolerances.xml
@@ -12,8 +12,7 @@
     <test id="scenario1-2-retrieve-allergyintolerance">
         <name value="Scenario 1.2"/>
         <description value="Serve no AllergyIntolerance resources."/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="0"/>
         <nts:include value="assert.response.noEntries" scope="common"/>

--- a/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances.xml
+++ b/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-1-serve-allergyintolerances.xml
@@ -12,8 +12,7 @@
     <test id="scenario1-1-serve-allergyintolerance">
         <name value="Scenario 1.1"/>
         <description value="Serve all AllergyIntolerance resources of XXX-Stalewska."/>
-        <nts:include value="medmij/test.phr.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="4"/>
     </test>

--- a/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances.xml
+++ b/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-2-serve-allergyintolerances.xml
@@ -12,8 +12,7 @@
     <test id="scenario1-2-serve-allergyintolerance">
         <name value="Scenario 1.2"/>
         <description value="Serve all AllergyIntolerance resources of XXX-Smits."/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="4"/>
     </test>

--- a/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances.xml
+++ b/src/AllergyIntolerance-3-0/Cert/XIS-Server/AllergyIntoleranceConv/medmij-allergyintolerance-xis-1-3-serve-allergyintolerances.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://hl7.org/fhir/STU3/testscript.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TestScript xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript"
-    nts:scenario="client">
+    nts:scenario="server">
     <id value="aic-xis-1-3-serve-allergyintolerance"/>
     <version value="stu3-2.0"/>
     <name
@@ -12,8 +12,7 @@
     <test id="scenario1-2-serve-allergyintolerance">
         <name value="Scenario 1.3"/>
         <description value="Serve no AllergyIntolerance resources of XXX-Daalen."/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="0"/>
         <nts:include value="assert.response.noEntries" scope="common"/>

--- a/src/BgLZ-3-0/Cert/XIS-Server/medmij-bglz-xis-1-1-serve-bglz.xml
+++ b/src/BgLZ-3-0/Cert/XIS-Server/medmij-bglz-xis-1-1-serve-bglz.xml
@@ -12,10 +12,9 @@
         <name value="Scenario 1.1 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -25,10 +24,9 @@
     <test id="02-serve-TreatmentDirective">
         <name value="Scenario 1.1 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Consent" count="1"/>
     </test>
@@ -36,10 +34,9 @@
     <test id="03-serve-AdvanceDirective">
         <name value="Scenario 1.1 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Consent" count="1"/>
     </test>
@@ -47,8 +44,7 @@
     <test id="04-serve-Problem">
         <name value="Scenario 1.1 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Condition" count="8"/>
     </test>
@@ -56,8 +52,7 @@
     <test id="05-serve-AllergyIntolerance">
         <name value="Scenario 1.1 - AllergyIntolerance"/>
         <description value="Serve AllergyIntolerance resource(s) for HCIM AllergyIntolerance"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="2"/>
     </test>
@@ -66,10 +61,9 @@
         <name value="Scenario 1.1 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for last known HCIM LaboratoryTestResult and include related Observations and Specimen"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="5"/>
     </test>
@@ -77,8 +71,7 @@
     <test id="07-serve-Procedure">
         <name value="Scenario 1.1 - Procedure"/>
         <description value="Serve Procedure resource(s) for HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Procedure"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Procedure"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Procedure" count="4"/>
     </test>
@@ -87,9 +80,9 @@
         <name value="Scenario 1.1 - CarePlan"/>
         <description
             value="Serve CarePlan resource(s) for HCIMs NursingIntervention, TreatmentObjective, MedicalDevice and OutcomeOfCare"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="CarePlan"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
+            resource="CarePlan"
             params="?_include=CarePlan:activity-goal:Goal&amp;_include=CarePlan:activity-outcomereference:Observation&amp;_include=CarePlan:activity-medicaldevice:DeviceUseStatement&amp;_include:recurse=DeviceUseStatement:device:Device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common" nts:in-targets="#default"
             resource="CarePlan" count="1"/>
 
@@ -103,10 +96,9 @@
         <name value="Scenario 1.1 - CareTeam"/>
         <description
             value="Serve CarePlan resource(s) for HCIM HealthProfessional and HealthcareProvider"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="CareTeam"
             params="?_include=CareTeam:participant"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="CareTeam" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/BgLZ-3-0/Cert/XIS-Server/medmij-bglz-xis-1-2-serve-bglz.xml
+++ b/src/BgLZ-3-0/Cert/XIS-Server/medmij-bglz-xis-1-2-serve-bglz.xml
@@ -12,10 +12,9 @@
         <name value="Scenario 1.2 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
     </test>
@@ -23,36 +22,32 @@
     <test id="02-serve-TreatmentDirective">
         <name value="Scenario 1.2 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="03-serve-AdvanceDirective">
         <name value="Scenario 1.2 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="04-serve-Problem">
         <name value="Scenario 1.2 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="05-serve-AllergyIntolerance">
         <name value="Scenario 1.2 - AllergyIntolerance"/>
         <description value="Serve AllergyIntolerance resource(s) for HCIM AllergyIntolerance"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -60,17 +55,16 @@
         <name value="Scenario 1.2 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for last known HCIM LaboratoryTestResult and include related Observations and Specimen"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
+            resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="07-serve-Procedure">
         <name value="Scenario 1.2 - Procedure"/>
         <description value="Serve Procedure resource(s) for HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Procedure"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Procedure"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -78,10 +72,9 @@
         <name value="Scenario 1.2 - CarePlan"/>
         <description
             value="Serve CarePlan resource(s) for HCIMs NursingIntervention, TreatmentObjective, MedicalDevice and OutcomeOfCare"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="CarePlan"
             params="?_include=CarePlan:activity-goal:Goal&amp;_include=CarePlan:activity-outcomereference:Observation&amp;_include=CarePlan:activity-medicaldevice:DeviceUseStatement&amp;_include:recurse=DeviceUseStatement:device:Device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -89,9 +82,9 @@
         <name value="Scenario 1.2 - CareTeam"/>
         <description
             value="Serve CarePlan resource(s) for HCIM HealthProfessional and HealthcareProvider"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="CareTeam"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
+            resource="CareTeam"
             params="?_include=CareTeam:participant"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 </TestScript>

--- a/src/BgZ-3-0/Cert/XIS-Server/medmij-bgz-xis-1-1-serve-bgz.xml
+++ b/src/BgZ-3-0/Cert/XIS-Server/medmij-bgz-xis-1-1-serve-bgz.xml
@@ -12,10 +12,9 @@
         <name value="Scenario 1.1 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -25,10 +24,9 @@
     <test id="02-serve-Payer">
         <name value="Scenario 1.1 - Payer"/>
         <description value="Serve Coverage resource(s) including the insurer for HCIM Payer"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Coverage"
             params="?_include=Coverage:payor:Patient&amp;_include=Coverage:payor:Organization"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Coverage" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -38,10 +36,9 @@
     <test id="03-serve-TreatmentDirective">
         <name value="Scenario 1.1 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Consent" count="1"/>
     </test>
@@ -49,10 +46,9 @@
     <test id="04-serve-AdvanceDirective">
         <name value="Scenario 1.1 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Consent" count="1"/>
     </test>
@@ -60,10 +56,9 @@
     <test id="05-serve-FunctionalOrMentalStatus">
         <name value="Scenario 1.1 - FunctionalOrMentalStatus"/>
         <description value="Serve Observation resource(s) for HCIM FunctionalOrMentalStatus"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|118228005,http://snomed.info/sct|384821006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -71,8 +66,7 @@
     <test id="06-serve-Problem">
         <name value="Scenario 1.1 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Condition" count="6"/>
     </test>
@@ -80,10 +74,9 @@
     <test id="07-serve-LivingSituation">
         <name value="Scenario 1.1 - LivingSituation"/>
         <description value="Serve Observation resource(s) for HCIM LivingSituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|365508006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -91,10 +84,9 @@
     <test id="08-serve-DrugUse">
         <name value="Scenario 1.1 - DrugUse"/>
         <description value="Serve Observation resource(s) for HCIM DrugUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228366006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -102,10 +94,9 @@
     <test id="09-serve-AlcoholUse">
         <name value="Scenario 1.1 - AlcoholUse"/>
         <description value="Serve Observation resource(s) for HCIM AlcoholUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228273003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -113,10 +104,9 @@
     <test id="10-serve-TobaccoUse">
         <name value="Scenario 1.1 - TobaccoUse"/>
         <description value="Serve Observation resource(s) for HCIM TobaccoUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365980008"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -124,8 +114,7 @@
     <test id="11-serve-NutritionAdvice">
         <name value="Scenario 1.1 - NutritionAdvice"/>
         <description value="Serve NutritionOrder resource(s) for HCIM NutritionAdvice"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="NutritionOrder"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="NutritionOrder"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="NutritionOrder" count="1"/>
     </test>
@@ -133,8 +122,7 @@
     <test id="12-serve-Alert">
         <name value="Scenario 1.1 - Alert"/>
         <description value="Serve Flag resource(s) for HCIM Alert"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Flag"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Flag"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Flag" count="1"/>
     </test>
@@ -142,8 +130,7 @@
     <test id="13-serve-AllergyIntolerance">
         <name value="Scenario 1.1 - AllergyIntolerance"/>
         <description value="Serve AllergyIntolerance resource(s) for HCIM AllergyIntolerance"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="1"/>
     </test>
@@ -152,10 +139,9 @@
         <name value="Scenario 1.1 - MedicationUse"/>
         <description
             value="Serve MedicationStatement resource(s) for HCIM MedicationUse and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationStatement"
             params="?category=urn:oid:2.16.840.1.113883.2.4.3.11.60.20.77.5.3|6&amp;_include=MedicationStatement:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationStatement" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -166,10 +152,9 @@
         <name value="Scenario 1.1 - MedicationAgreement"/>
         <description
             value="Serve MedicationRequest resource(s) for HCIM MedicationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationRequest"
             params="?category=http://snomed.info/sct|16076005&amp;_include=MedicationRequest:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationRequest" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -180,10 +165,9 @@
         <name value="Scenario 1.1 - AdministrationAgreement"/>
         <description
             value="Serve MedicationDispense resource(s) for HCIM AdministrationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationDispense"
             params="?category=http://snomed.info/sct|422037009&amp;_include=MedicationDispense:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationDispense" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -194,10 +178,9 @@
         <name value="Scenario 1.1 - MedicalDevice"/>
         <description
             value="Serve DeviceUseStatement resource(s) for HCIM MedicalDevice and include device"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceUseStatement"
             params="?_include=DeviceUseStatement:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DeviceUseStatement" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -208,10 +191,9 @@
     <test id="18-serve-Vaccination">
         <name value="Scenario 1.1 - Vaccination"/>
         <description value="Serve Immunization resource(s) for HCIM Vaccination"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Immunization"
             params="?status=completed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Immunization" count="1"/>
     </test>
@@ -219,10 +201,9 @@
     <test id="19-serve-BloodPressure">
         <name value="Scenario 1.1 - BloodPressure"/>
         <description value="Serve Observation resource(s) for last known HCIM BloodPressure"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|85354-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -230,10 +211,9 @@
     <test id="20-serve-BodyWeight">
         <name value="Scenario 1.1 - BodyWeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyWeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|29463-7"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -241,10 +221,9 @@
     <test id="21-serve-BodyHeight">
         <name value="Scenario 1.1 - BodyHeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyHeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8302-2,http://loinc.org|8306-3,http://loinc.org|8308-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -253,10 +232,9 @@
         <name value="Scenario 1.1 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for last known chemistry related HCIM LaboratoryTestResult and include specimen and related observations"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -266,10 +244,9 @@
     <test id="23-serve-Procedure">
         <name value="Scenario 1.1 - Procedure"/>
         <description value="Serve Procedure resource(s) for surgical related HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Procedure"
             params="?category=http://snomed.info/sct|387713003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Procedure" count="2"/>
     </test>
@@ -278,10 +255,9 @@
         <name value="Scenario 1.1 - Contact"/>
         <description
             value="Serve Encounter resource(s) for hospital admission related related HCIM Contact"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Encounter"
             params="?class=http://hl7.org/fhir/v3/ActCode|IMP,http://hl7.org/fhir/v3/ActCode|ACUTE,http://hl7.org/fhir/v3/ActCode|NONAC"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Encounter" count="1"/>
     </test>
@@ -290,10 +266,9 @@
         <name value="Scenario 1.1 - PlannedCareActivity-ProcedureRequest"/>
         <description
             value="Serve ProcedureRequest resource(s) for active HCIM PlannedCareActivity-ProcedureRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ProcedureRequest"
             params="?status=active"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="ProcedureRequest" count="1"/>
     </test>
@@ -302,9 +277,8 @@
         <name value="Scenario 1.1 - PlannedCareActivity-ImmunizationRecommendation"/>
         <description
             value="Serve ImmunizationRecommendation resource(s) for HCIM PlannedCareActivity-ImmunizationRecommendation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ImmunizationRecommendation"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="ImmunizationRecommendation" count="1"/>
     </test>
@@ -312,10 +286,9 @@
     <test id="27-serve-PlannedCareActivity-Appointment">
         <name value="Scenario 1.1 - PlannedCareActivity-Appointment"/>
         <description value="Serve Appointment resource(s) for HCIM PlannedCareActivity-Appointment"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Appointment"
             params="?status=booked,pending,proposed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Appointment" count="1"/>
     </test>
@@ -324,10 +297,9 @@
         <name value="Scenario 1.1 - PlannedCareActivity-DeviceRequest"/>
         <description
             value="Serve DeviceRequest resource(s) for HCIM PlannedCareActivity-DeviceRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceRequest"
             params="?status=active&amp;_include=DeviceRequest:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DeviceRequest" count="1"/>
         <nts:include value="assert.response.numResources" scope="common" resource="Device" count="1"

--- a/src/BgZ-3-0/Cert/XIS-Server/medmij-bgz-xis-1-2-serve-bgz.xml
+++ b/src/BgZ-3-0/Cert/XIS-Server/medmij-bgz-xis-1-2-serve-bgz.xml
@@ -12,10 +12,9 @@
         <name value="Scenario 1.2 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" 
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
     </test>
@@ -23,112 +22,100 @@
     <test id="02-serve-Payer">
         <name value="Scenario 1.2 - Payer"/>
         <description value="Serve Coverage resource(s) including the insurer for HCIM Payer"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Coverage"
             params="?_include=Coverage:payor:Patient&amp;_include=Coverage:payor:Organization"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="03-serve-TreatmentDirective">
         <name value="Scenario 1.2 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="04-serve-AdvanceDirective">
         <name value="Scenario 1.2 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="05-serve-FunctionalOrMentalStatus">
         <name value="Scenario 1.2 - FunctionalOrMentalStatus"/>
         <description value="Serve Observation resource(s) for HCIM FunctionalOrMentalStatus"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|118228005,http://snomed.info/sct|384821006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="06-serve-Problem">
         <name value="Scenario 1.2 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="07-serve-LivingSituation">
         <name value="Scenario 1.2 - LivingSituation"/>
         <description value="Serve Observation resource(s) for HCIM LivingSituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|365508006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="08-serve-DrugUse">
         <name value="Scenario 1.2 - DrugUse"/>
         <description value="Serve Observation resource(s) for HCIM DrugUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228366006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="09-serve-AlcoholUse">
         <name value="Scenario 1.2 - AlcoholUse"/>
         <description value="Serve Observation resource(s) for HCIM AlcoholUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228273003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="10-serve-TobaccoUse">
         <name value="Scenario 1.2 - TobaccoUse"/>
         <description value="Serve Observation resource(s) for HCIM TobaccoUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365980008"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="11-serve-NutritionAdvice">
         <name value="Scenario 1.2 - NutritionAdvice"/>
         <description value="Serve NutritionOrder resource(s) for HCIM NutritionAdvice"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="NutritionOrder"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="NutritionOrder"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="12-serve-Alert">
         <name value="Scenario 1.2 - Alert"/>
         <description value="Serve Flag resource(s) for HCIM Alert"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Flag"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Flag"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="13-serve-AllergyIntolerance">
         <name value="Scenario 1.2 - AllergyIntolerance"/>
         <description value="Serve AllergyIntolerance resource(s) for HCIM AllergyIntolerance"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -136,10 +123,9 @@
         <name value="Scenario 1.2 - MedicationUse"/>
         <description
             value="Serve MedicationStatement resource(s) for HCIM MedicationUse and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationStatement"
             params="?category=urn:oid:2.16.840.1.113883.2.4.3.11.60.20.77.5.3|6&amp;_include=MedicationStatement:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -147,10 +133,9 @@
         <name value="Scenario 1.2 - MedicationAgreement"/>
         <description
             value="Serve MedicationRequest resource(s) for HCIM MedicationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationRequest"
             params="?category=http://snomed.info/sct|16076005&amp;_include=MedicationRequest:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -158,10 +143,9 @@
         <name value="Scenario 1.2 - AdministrationAgreement"/>
         <description
             value="Serve MedicationDispense resource(s) for HCIM AdministrationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationDispense"
             params="?category=http://snomed.info/sct|422037009&amp;_include=MedicationDispense:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -169,50 +153,45 @@
         <name value="Scenario 1.2 - MedicalDevice"/>
         <description
             value="Serve DeviceUseStatement resource(s) for HCIM MedicalDevice and include device"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceUseStatement"
             params="?_include=DeviceUseStatement:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="18-serve-Vaccination">
         <name value="Scenario 1.2 - Vaccination"/>
         <description value="Serve Immunization resource(s) for HCIM Vaccination"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Immunization"
             params="?status=completed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="19-serve-BloodPressure">
         <name value="Scenario 1.2 - BloodPressure"/>
         <description value="Serve Observation resource(s) for last known HCIM BloodPressure"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|85354-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="20-serve-BodyWeight">
         <name value="Scenario 1.2 - BodyWeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyWeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|29463-7"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="21-serve-BodyHeight">
         <name value="Scenario 1.2 - BodyHeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyHeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8302-2,http://loinc.org|8306-3,http://loinc.org|8308-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -220,20 +199,18 @@
         <name value="Scenario 1.2 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for last known chemistry related HCIM LaboratoryTestResult and include specimen and related observations"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="23-serve-Procedure">
         <name value="Scenario 1.2 - Procedure"/>
         <description value="Serve Procedure resource(s) for surgical related HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Procedure"
             params="?category=http://snomed.info/sct|387713003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -241,10 +218,9 @@
         <name value="Scenario 1.2 - Contact"/>
         <description
             value="Serve Encounter resource(s) for hospital admission related related HCIM Contact"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Encounter"
             params="?class=http://hl7.org/fhir/v3/ActCode|IMP,http://hl7.org/fhir/v3/ActCode|ACUTE,http://hl7.org/fhir/v3/ActCode|NONAC"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -252,10 +228,9 @@
         <name value="Scenario 1.2 - PlannedCareActivity-ProcedureRequest"/>
         <description
             value="Serve ProcedureRequest resource(s) for active HCIM PlannedCareActivity-ProcedureRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ProcedureRequest"
             params="?status=active"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -263,19 +238,17 @@
         <name value="Scenario 1.2 - PlannedCareActivity-ImmunizationRecommendation"/>
         <description
             value="Serve ImmunizationRecommendation resource(s) for HCIM PlannedCareActivity-ImmunizationRecommendation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ImmunizationRecommendation"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="27-serve-PlannedCareActivity-Appointment">
         <name value="Scenario 1.2 - PlannedCareActivity-Appointment"/>
         <description value="Serve Appointment resource(s) for HCIM PlannedCareActivity-Appointment"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Appointment"
             params="?status=booked,pending,proposed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -283,10 +256,9 @@
         <name value="Scenario 1.2 - PlannedCareActivity-DeviceRequest"/>
         <description
             value="Serve DeviceRequest resource(s) for HCIM PlannedCareActivity-DeviceRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceRequest"
             params="?status=active&amp;_include=DeviceRequest:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 </TestScript>

--- a/src/BgZ-extended-3-0/Test/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext.xml
+++ b/src/BgZ-extended-3-0/Test/XIS-Server/medmij-bgz-xis-1-1-serve-bgz-ext.xml
@@ -12,10 +12,9 @@
         <name value="Scenario 1.1 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -25,10 +24,9 @@
     <test id="02-serve-Payer">
         <name value="Scenario 1.1 - Payer"/>
         <description value="Serve Coverage resource(s) including the insurer for HCIM Payer"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Coverage"
             params="?_include=Coverage:payor:Patient&amp;_include=Coverage:payor:Organization"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Coverage" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -38,10 +36,9 @@
     <test id="03-serve-TreatmentDirective">
         <name value="Scenario 1.1 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Consent" count="1"/>
     </test>
@@ -49,10 +46,9 @@
     <test id="04-serve-AdvanceDirective">
         <name value="Scenario 1.1 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Consent" count="1"/>
     </test>
@@ -60,10 +56,9 @@
     <test id="05-serve-FunctionalOrMentalStatus">
         <name value="Scenario 1.1 - FunctionalOrMentalStatus"/>
         <description value="Serve Observation resource(s) for HCIM FunctionalOrMentalStatus"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|118228005,http://snomed.info/sct|384821006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="3"/>
     </test>
@@ -71,8 +66,7 @@
     <test id="06-serve-Problem">
         <name value="Scenario 1.1 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Condition" count="7"/>
     </test>
@@ -80,10 +74,9 @@
     <test id="07-serve-LivingSituation">
         <name value="Scenario 1.1 - LivingSituation"/>
         <description value="Serve Observation resource(s) for HCIM LivingSituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|365508006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -91,10 +84,9 @@
     <test id="08-serve-DrugUse">
         <name value="Scenario 1.1 - DrugUse"/>
         <description value="Serve Observation resource(s) for HCIM DrugUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228366006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -102,10 +94,9 @@
     <test id="09-serve-AlcoholUse">
         <name value="Scenario 1.1 - AlcoholUse"/>
         <description value="Serve Observation resource(s) for HCIM AlcoholUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228273003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -113,10 +104,9 @@
     <test id="10-serve-TobaccoUse">
         <name value="Scenario 1.1 - TobaccoUse"/>
         <description value="Serve Observation resource(s) for HCIM TobaccoUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365980008"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -124,8 +114,7 @@
     <test id="11-serve-NutritionAdvice">
         <name value="Scenario 1.1 - NutritionAdvice"/>
         <description value="Serve Flag resource(s) for HCIM NutritionAdvice"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="NutritionOrder"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="NutritionOrder"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="NutritionOrder" count="1"/>
     </test>
@@ -133,8 +122,7 @@
     <test id="12-serve-Alert">
         <name value="Scenario 1.1 - Alert"/>
         <description value="Serve NutritionOrder resource(s) for HCIM Alert"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Flag"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Flag"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Flag" count="3"/>
     </test>
@@ -142,8 +130,7 @@
     <test id="13-serve-AllergyIntolerance">
         <name value="Scenario 1.1 - AllergyIntolerance"/>
         <description value="Serve AllergyIntolerance resource(s) for HCIM AllergyIntolerance"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="2"/>
     </test>
@@ -152,10 +139,9 @@
         <name value="Scenario 1.1 - MedicationUse"/>
         <description
             value="Serve MedicationStatement resource(s) for HCIM MedicationUse and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationStatement"
             params="?category=urn:oid:2.16.840.1.113883.2.4.3.11.60.20.77.5.3|6&amp;_include=MedicationStatement:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationStatement" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -166,10 +152,9 @@
         <name value="Scenario 1.1 - MedicationAgreement"/>
         <description
             value="Serve MedicationRequest resource(s) for HCIM MedicationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationRequest"
             params="?category=http://snomed.info/sct|16076005&amp;_include=MedicationRequest:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationRequest" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -180,10 +165,9 @@
         <name value="Scenario 1.1 - AdministrationAgreement"/>
         <description
             value="Serve MedicationDispense resource(s) for HCIM AdministrationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationDispense"
             params="?category=http://snomed.info/sct|422037009&amp;_include=MedicationDispense:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationDispense" count="3"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -194,10 +178,9 @@
         <name value="Scenario 1.1 - MedicalDevice"/>
         <description
             value="Serve DeviceUseStatement resource(s) for HCIM MedicalDevice and include device"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceUseStatement"
             params="?_include=DeviceUseStatement:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DeviceUseStatement" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -208,10 +191,9 @@
     <test id="18-serve-Vaccination">
         <name value="Scenario 1.1 - Vaccination"/>
         <description value="Serve Immunization resource(s) for HCIM Vaccination"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Immunization"
             params="?status=completed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Immunization" count="4"/>
     </test>
@@ -219,10 +201,9 @@
     <test id="19-serve-BloodPressure">
         <name value="Scenario 1.1 - BloodPressure"/>
         <description value="Serve Observation resource(s) for last known HCIM BloodPressure"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|85354-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -230,10 +211,9 @@
     <test id="20-serve-BodyWeight">
         <name value="Scenario 1.1 - BodyWeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyWeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|29463-7"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -241,10 +221,9 @@
     <test id="21-serve-BodyHeight">
         <name value="Scenario 1.1 - BodyHeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyHeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|8302-2,http://loinc.org|8306-3,http://loinc.org|8308-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>
@@ -253,10 +232,9 @@
         <name value="Scenario 1.1 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for last known chemistry related HCIM LaboratoryTestResult and include specimen and related observations"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="2"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -266,10 +244,9 @@
     <test id="23-serve-Procedure">
         <name value="Scenario 1.1 - Procedure"/>
         <description value="Serve Procedure resource(s) for surgical related HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Procedure"
             params="?category=http://snomed.info/sct|387713003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Procedure" count="5"/>
     </test>
@@ -278,10 +255,9 @@
         <name value="Scenario 1.1 - Contact"/>
         <description
             value="Serve Encounter resource(s) for hospital admission related related HCIM Contact"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Encounter"
             params="?class=http://hl7.org/fhir/v3/ActCode|IMP,http://hl7.org/fhir/v3/ActCode|ACUTE,http://hl7.org/fhir/v3/ActCode|NONAC"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Encounter" count="2"
             additionalDescription="Set to warningOnly because of https://bits.nictiz.nl/browse/MM-1497."
@@ -292,10 +268,9 @@
         <name value="Scenario 1.1 - PlannedCareActivity-ProcedureRequest"/>
         <description
             value="Serve ProcedureRequest resource(s) for active HCIM PlannedCareActivity-ProcedureRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ProcedureRequest"
             params="?status=active"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="ProcedureRequest" count="7"/>
     </test>
@@ -304,9 +279,8 @@
         <name value="Scenario 1.1 - PlannedCareActivity-ImmunizationRecommendation"/>
         <description
             value="Serve ImmunizationRecommendation resource(s) for HCIM PlannedCareActivity-ImmunizationRecommendation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ImmunizationRecommendation"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="ImmunizationRecommendation" count="3"/>
     </test>
@@ -314,10 +288,9 @@
     <test id="27-serve-PlannedCareActivity-Appointment">
         <name value="Scenario 1.1 - PlannedCareActivity-Appointment"/>
         <description value="Serve Appointment resource(s) for HCIM PlannedCareActivity-Appointment"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Appointment"
             params="?status=booked,pending,proposed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Appointment" count="1"/>
     </test>
@@ -326,10 +299,9 @@
         <name value="Scenario 1.1 - PlannedCareActivity-DeviceRequest"/>
         <description
             value="Serve DeviceRequest resource(s) for HCIM PlannedCareActivity-DeviceRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceRequest"
             params="?status=active&amp;_include=DeviceRequest:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DeviceRequest" count="1"/>
         <nts:include value="assert.response.numResources" scope="common" resource="Device" count="1"

--- a/src/BgZ-extended-3-0/Test/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext.xml
+++ b/src/BgZ-extended-3-0/Test/XIS-Server/medmij-bgz-xis-1-5-serve-bgz-ext.xml
@@ -12,9 +12,8 @@
         <name value="Scenario 1.5 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Patient"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common" resource="Patient"
             count="1"/>
     </test>
@@ -22,104 +21,92 @@
     <test id="02-serve-Payer">
         <name value="Scenario 1.5 - Payer"/>
         <description value="Serve Coverage resource(s) including the insurer for HCIM Payer"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Coverage"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Coverage"
             params="?_include=Coverage:payor:Patient&amp;_include=Coverage:payor:Organization"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="03-serve-TreatmentDirective">
         <name value="Scenario 1.5 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Consent"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="04-serve-AdvanceDirective">
         <name value="Scenario 1.5 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Consent"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="05-serve-FunctionalOrMentalStatus">
         <name value="Scenario 1.5 - FunctionalOrMentalStatus"/>
         <description value="Serve Observation resource(s) for HCIM FunctionalOrMentalStatus"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|118228005,http://snomed.info/sct|384821006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="06-serve-Problem">
         <name value="Scenario 1.5 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="07-serve-LivingSituation">
         <name value="Scenario 1.5 - LivingSituation"/>
         <description value="Serve Observation resource(s) for HCIM LivingSituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|365508006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="08-serve-DrugUse">
         <name value="Scenario 1.5 - DrugUse"/>
         <description value="Serve Observation resource(s) for HCIM DrugUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="?code=http://snomed.info/sct|228366006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="09-serve-AlcoholUse">
         <name value="Scenario 1.5 - AlcoholUse"/>
         <description value="Serve Observation resource(s) for HCIM AlcoholUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="?code=http://snomed.info/sct|228273003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="10-serve-TobaccoUse">
         <name value="Scenario 1.5 - TobaccoUse"/>
         <description value="Serve Observation resource(s) for HCIM TobaccoUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="?code=http://snomed.info/sct|365980008"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="11-serve-NutritionAdvice">
         <name value="Scenario 1.5 - NutritionAdvice"/>
         <description value="Serve Flag resource(s) for HCIM NutritionAdvice"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="NutritionOrder"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="NutritionOrder"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="12-serve-Alert">
         <name value="Scenario 1.5 - Alert"/>
         <description value="Serve NutritionOrder resource(s) for HCIM Alert"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Flag"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Flag"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="13-serve-AllergyIntolerance">
         <name value="Scenario 1.5 - AllergyIntolerance"/>
         <description value="Serve AllergyIntolerance resource(s) for HCIM AllergyIntolerance"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="AllergyIntolerance"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="AllergyIntolerance"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -127,10 +114,9 @@
         <name value="Scenario 1.5 - MedicationUse"/>
         <description
             value="Serve MedicationStatement resource(s) for HCIM MedicationUse and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationStatement"
             params="?category=urn:oid:2.16.840.1.513883.2.4.3.11.60.20.77.5.3|6&amp;_include=MedicationStatement:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -138,10 +124,9 @@
         <name value="Scenario 1.5 - MedicationAgreement"/>
         <description
             value="Serve MedicationRequest resource(s) for HCIM MedicationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationRequest"
             params="?category=http://snomed.info/sct|16076005&amp;_include=MedicationRequest:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -149,10 +134,9 @@
         <name value="Scenario 1.5 - AdministrationAgreement"/>
         <description
             value="Serve MedicationDispense resource(s) for HCIM AdministrationAgreement and include medication"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationDispense"
             params="?category=http://snomed.info/sct|422037009&amp;_include=MedicationDispense:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -160,45 +144,40 @@
         <name value="Scenario 1.5 - MedicalDevice"/>
         <description
             value="Serve DeviceUseStatement resource(s) for HCIM MedicalDevice and include device"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceUseStatement" params="?_include=DeviceUseStatement:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="18-serve-Vaccination">
         <name value="Scenario 1.5 - Vaccination"/>
         <description value="Serve Immunization resource(s) for HCIM Vaccination"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Immunization"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Immunization"
             params="?status=completed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="19-serve-BloodPressure">
         <name value="Scenario 1.5 - BloodPressure"/>
         <description value="Serve Observation resource(s) for last known HCIM BloodPressure"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="/$lastn?code=http://loinc.org|85354-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="20-serve-BodyWeight">
         <name value="Scenario 1.5 - BodyWeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyWeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="/$lastn?code=http://loinc.org|29463-7"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="21-serve-BodyHeight">
         <name value="Scenario 1.5 - BodyHeight"/>
         <description value="Serve Observation resource(s) for last known HCIM BodyHeight"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="/$lastn?code=http://loinc.org|8302-2,http://loinc.org|8306-3,http://loinc.org|8308-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -206,18 +185,16 @@
         <name value="Scenario 1.5 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for last known chemistry related HCIM LaboratoryTestResult and include specimen and related observations"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Observation"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="23-serve-Procedure">
         <name value="Scenario 1.5 - Procedure"/>
         <description value="Serve Procedure resource(s) for surgical related HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Procedure"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Procedure"
             params="?category=http://snomed.info/sct|387713003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -225,9 +202,8 @@
         <name value="Scenario 1.5 - Contact"/>
         <description
             value="Serve Encounter resource(s) for hospital admission related related HCIM Contact"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Encounter"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Encounter"
             params="?class=http://hl7.org/fhir/v3/ActCode|IMP,http://hl7.org/fhir/v3/ActCode|ACUTE,http://hl7.org/fhir/v3/ActCode|NONAC"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -235,9 +211,8 @@
         <name value="Scenario 1.5 - PlannedCareActivity-ProcedureRequest"/>
         <description
             value="Serve ProcedureRequest resource(s) for active HCIM PlannedCareActivity-ProcedureRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ProcedureRequest" params="?status=active"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -245,18 +220,16 @@
         <name value="Scenario 1.5 - PlannedCareActivity-ImmunizationRecommendation"/>
         <description
             value="Serve ImmunizationRecommendation resource(s) for HCIM PlannedCareActivity-ImmunizationRecommendation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="ImmunizationRecommendation"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="27-serve-PlannedCareActivity-Appointment">
         <name value="Scenario 1.5 - PlannedCareActivity-Appointment"/>
         <description value="Serve Appointment resource(s) for HCIM PlannedCareActivity-Appointment"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Appointment"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Appointment"
             params="?status=booked,pending,proposed"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -264,9 +237,8 @@
         <name value="Scenario 1.5 - PlannedCareActivity-DeviceRequest"/>
         <description
             value="Serve DeviceRequest resource(s) for HCIM PlannedCareActivity-DeviceRequest"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DeviceRequest" params="?status=active&amp;_include=DeviceRequest:device"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 </TestScript>

--- a/src/GGZ-2-0/Cert/XIS-Server/medmij-ggz-xis-1-1-serve.xml
+++ b/src/GGZ-2-0/Cert/XIS-Server/medmij-ggz-xis-1-1-serve.xml
@@ -12,10 +12,9 @@
         <name value="Scenario 1.1 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -25,10 +24,9 @@
     <test id="02-serve-Payer">
         <name value="Scenario 1.1 - Payer"/>
         <description value="Serve Coverage resource(s) including the insurer for HCIM Payer"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Coverage"
             params="?_include=Coverage:payor:Patient&amp;_include=Coverage:payor:Organization"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Coverage" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"
@@ -38,10 +36,9 @@
     <test id="03-serve-TreatmentDirective">
         <name value="Scenario 1.1 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="Consent" count="1"
             codedElement="category" code="11291000146105"/>
@@ -50,10 +47,9 @@
     <test id="04-serve-AdvanceDirective">
         <name value="Scenario 1.1 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="Consent" count="1"
             codedElement="category" code="11341000146107"/>
@@ -62,10 +58,9 @@
     <test id="05-serve-FunctionalOrMentalStatus">
         <name value="Scenario 1.1 - FunctionalOrMentalStatus"/>
         <description value="Serve Observation resource(s) for HCIM FunctionalOrMentalStatus"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?category=http://snomed.info/sct|118228005,http://snomed.info/sct|384821006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="2"/>
     </test>
@@ -73,8 +68,7 @@
     <test id="06-serve-Problem">
         <name value="Scenario 1.1 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Condition" count="1"/>
     </test>
@@ -82,10 +76,9 @@
     <test id="07-serve-DrugUse">
         <name value="Scenario 1.1 - DrugUse"/>
         <description value="Serve Observation resource(s) for HCIM DrugUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228366006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode"
             scope="common" resource="Observation"
             count="1" code="228366006"/>
@@ -94,10 +87,9 @@
     <test id="08-serve-AlcoholUse">
         <name value="Scenario 1.1 - AlcoholUse"/>
         <description value="Serve Observation resource(s) for HCIM AlcoholUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228273003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode"
             scope="common" resource="Observation"
             count="1" code="228273003"/>
@@ -106,10 +98,9 @@
     <test id="09-serve-TobaccoUse">
         <name value="Scenario 1.1 - TobaccoUse"/>
         <description value="Serve Observation resource(s) for HCIM TobaccoUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365980008"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode"
             scope="common" resource="Observation"
             count="1" code="365980008"/>
@@ -118,10 +109,9 @@
     <test id="10-serve-LivingSituation">
         <name value="Scenario 1.1 - LivingSituation"/>
         <description value="Serve Observation resource(s) for HCIM LivingSituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|365508006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="Observation" count="1" code="365508006"/>
     </test>
@@ -129,10 +119,9 @@
     <test id="11-serve-FamilySituation">
         <name value="Scenario 1.1 - FamilySituation"/>
         <description value="Serve Observation resource(s) for HCIM FamilySituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365470003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="Observation" count="1" code="365470003"/>
     </test>
@@ -140,10 +129,9 @@
     <test id="12-serve-ParticipationInSociety">
         <name value="Scenario 1.1 - ParticipationInSociety"/>
         <description value="Serve Observation resource(s) for HCIM ParticipationInSociety"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|314845004"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="Observation" count="1" code="314845004"/>
     </test>
@@ -151,10 +139,9 @@
     <test id="13-serve-HelpFromOthers">
         <name value="Scenario 1.1 - HelpFromOthers"/>
         <description value="Serve CarePlan resource(s) for HCIM HelpFromOthers"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="CarePlan"
             params="?category=http://snomed.info/sct|243114000"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="CarePlan" count="1" codedElement="category" code="243114000"/>
     </test>
@@ -163,10 +150,9 @@
         <name value="Scenario 1.1 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for the last known chemistry HCIM LaboratoryTestResult"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResourcesWithCode" scope="common"
             resource="Observation" count="3"
             codedElement="category" code="49581000146104"/>
@@ -175,10 +161,9 @@
     <test id="15-serve-GeneralMeasurement">
         <name value="Scenario 1.1 - GeneralMeasurement"/>
         <description value="Serve Observation resource(s) for survey HCIM GeneralMeasurement"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?category=http://hl7.org/fhir/observation-category|survey"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="14"/>
     </test>
@@ -186,8 +171,7 @@
     <test id="16-serve-Procedure">
         <name value="Scenario 1.1 - Procedure"/>
         <description value="Serve Procedure resource(s) for HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Procedure"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Procedure"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Procedure" count="1"/>
     </test>
@@ -195,8 +179,7 @@
     <test id="17-serve-TextResult">
         <name value="Scenario 1.1 - TextResult"/>
         <description value="Serve DiagnosticReport resource(s) for HCIM TextResult"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="DiagnosticReport"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="DiagnosticReport"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DiagnosticReport" count="1"/>
     </test>
@@ -204,10 +187,9 @@
     <test id="18-serve-CareTeam">
         <name value="Scenario 1.1 - CareTeam"/>
         <description value="Serve CateTeam resource(s) including the participants "/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="CareTeam"
             params="?_include=CareTeam:participant"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="CareTeam" count="1"/>
         <action>

--- a/src/GGZ-2-0/Cert/XIS-Server/medmij-ggz-xis-1-2-serve.xml
+++ b/src/GGZ-2-0/Cert/XIS-Server/medmij-ggz-xis-1-2-serve.xml
@@ -13,10 +13,9 @@
         <name value="Scenario 1.2 - Patient"/>
         <description
             value="Serve Patient resource including the patient's general practitioner for HCIM Patient"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
     </test>
@@ -24,118 +23,106 @@
     <test id="02-serve-Payer">
         <name value="Scenario 1.2 - Payer"/>
         <description value="Serve Coverage resource(s) including the insurer for HCIM Payer"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Coverage"
             params="?_include=Coverage:payor:Patient&amp;_include=Coverage:payor:Organization"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="03-serve-TreatmentDirective">
         <name value="Scenario 1.2 - TreatmentDirective"/>
         <description value="Serve Consent resource(s) for HCIM TreatmentDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11291000146105"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="04-serve-AdvanceDirective">
         <name value="Scenario 1.2 - AdvanceDirective"/>
         <description value="Serve Consent resource(s) for HCIM AdvanceDirective"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Consent"
             params="?category=http://snomed.info/sct|11341000146107"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="05-serve-FunctionalOrMentalStatus">
         <name value="Scenario 1.2 - FunctionalOrMentalStatus"/>
         <description value="Serve Observation resource(s) for HCIM FunctionalOrMentalStatus"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?category=http://snomed.info/sct|118228005,http://snomed.info/sct|384821006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="06-serve-Problem">
         <name value="Scenario 1.2 - Problem"/>
         <description value="Serve Condition resource(s) for HCIM Problem"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Condition"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Condition"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="07-serve-DrugUse">
         <name value="Scenario 1.2 - DrugUse"/>
         <description value="Serve Observation resource(s) for HCIM DrugUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228366006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="08-serve-AlcoholUse">
         <name value="Scenario 1.2 - AlcoholUse"/>
         <description value="Serve Observation resource(s) for HCIM AlcoholUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|228273003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="09-serve-TobaccoUse">
         <name value="Scenario 1.2 - TobaccoUse"/>
         <description value="Serve Observation resource(s) for HCIM TobaccoUse"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365980008"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="10-serve-LivingSituation">
         <name value="Scenario 1.2 - LivingSituation"/>
         <description value="Serve Observation resource(s) for HCIM LivingSituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://snomed.info/sct|365508006"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="11-serve-FamilySituation">
         <name value="Scenario 1.2 - FamilySituation"/>
         <description value="Serve Observation resource(s) for HCIM FamilySituation"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|365470003"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="12-serve-ParticipationInSociety">
         <name value="Scenario 1.2 - ParticipationInSociety"/>
         <description value="Serve Observation resource(s) for HCIM ParticipationInSociety"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://snomed.info/sct|314845004"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="13-serve-HelpFromOthers">
         <name value="Scenario 1.2 - HelpFromOthers"/>
         <description value="Serve CarePlan resource(s) for HCIM HelpFromOthers"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="CarePlan"
             params="?category=http://snomed.info/sct|243114000"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
@@ -143,46 +130,41 @@
         <name value="Scenario 1.2 - LaboratoryTestResult"/>
         <description
             value="Serve Observation resource(s) for the last known chemistry HCIM LaboratoryTestResult"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?category=http://snomed.info/sct|275711006&amp;_include=Observation:related-target&amp;_include=Observation:specimen"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="15-serve-GeneralMeasurement">
         <name value="Scenario 1.2 - GeneralMeasurement"/>
         <description value="Serve Observation resource(s) for survey HCIM GeneralMeasurement"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?category=http://hl7.org/fhir/observation-category|survey"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="16-serve-Procedure">
         <name value="Scenario 1.2 - Procedure"/>
         <description value="Serve Procedure resource(s) for HCIM Procedure"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Procedure"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Procedure"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="17-serve-TextResult">
         <name value="Scenario 1.2 - TextResult"/>
         <description value="Serve DiagnosticReport resource(s) for HCIM TextResult"/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="DiagnosticReport"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="DiagnosticReport"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 
     <test id="18-serve-CareTeam">
         <name value="Scenario 1.2 - CareTeam"/>
         <description value="Serve CateTeam resource(s) including the participants"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="CareTeam"
             params="?_include=CareTeam:participant"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.noEntries" scope="common"/>
     </test>
 

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-allergyintolerance.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-1-serve-allergyintolerance">
         <name value="Scenario 1.1 - Serve AllergyIntolerance"/>
         <description value="Scenario 1.1 - Serve all AllergyIntolerance resources of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="AllergyIntolerance"
             params="?category=medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="AllergyIntolerance" count="1"/>
     </test>

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-composition.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-composition.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-1-serve-composition">
         <name value="Scenario 1.1 - Serve Composition"/>
         <description value="Scenario 1.1 - Serve all Composition resources of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Composition"
             params="?type=http://loinc.org|67781-5"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Composition" count="18"/>
         <action>

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-current-medicationrequest.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-1-serve-medicationrequest">
         <name value="Scenario 1.1 - Serve MedicationRequest"/>
         <description value="Scenario 1.1 - Serve all MedicationRequest resources of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="MedicationRequest"
             params="?periodofuse=ge${DATE, T, D, -0}&amp;category=http://snomed.info/sct|16076005&amp;_include=MedicationRequest:medication"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="MedicationRequest" count="3"/>
         <action>

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-encounter.xml
@@ -12,8 +12,7 @@
     <test id="scenario1-1-serve-encounter">
         <name value="Scenario 1.1 - Serve Encounter"/>
         <description value="Scenario 1.1 - Serve all Encounter resources of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="Encounter"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="Encounter"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Encounter" count="18"/>
         <action>

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-episodesofcare.xml
@@ -12,8 +12,7 @@
     <test id="scenario1-1-serve-episodeofcare">
         <name value="Scenario 1.1 - Serve EpisodeOfCare"/>
         <description value="Scenario 1.1 - Serve all EpisodeOfCare resources of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common" resource="EpisodeOfCare"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common" resource="EpisodeOfCare"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="EpisodeOfCare" count="8"/>
         <action>

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-lab-diagn-observation.xml
@@ -14,10 +14,9 @@
         <name value="Scenario 1.1 - Serve Lab and Diagnostic Observations"/>
         <description
             value="Scenario 1.1 - Serve all Lab and Diagnostic Observations resources of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen|&amp;_include=Observation:related-target&amp;_include=Observation:specimen&amp;date=ge${CURRENTDATE,M,-14}"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="18"/>
         <action>

--- a/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-patient.xml
+++ b/src/GenPractData-2-0/Cert/XIS-Server/medmij-gpdata-xis-1-1-serve-patient.xml
@@ -11,10 +11,9 @@
     <test id="scenario1-1-serve-patient">
         <name value="Scenario 1.1 - Serve Patient"/>
         <description value="Scenario 1.1 - Serve Patient resource of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Patient"
             params="?_include=Patient:general-practitioner"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Patient" count="1"/>
         <nts:include value="assert.response.numResources" scope="common"

--- a/src/LaboratoryResults-2-0/Cert/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults.xml
+++ b/src/LaboratoryResults-2-0/Cert/XIS-Server/medmij-laboratoryresults-xis-1-1-retrieve-all-labresults.xml
@@ -10,11 +10,10 @@
     <test id="lab-Scenarioset1-1">
         <name value="Scenario 1.1"/>
         <description value="Scenario 1.1 - Query All LaboratoryResults of person 1."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?category=http://snomed.info/sct|49581000146104"
             description="Test XIS server to serve LaboratoryResults - All known LaboratoryResults Observarions from person 1."/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="3"/>
     </test>

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-1-1-serve-3-documentreference.xml
@@ -11,10 +11,9 @@
     <test id="scenario1-1-serve-3-documentreference">
         <name value="Scenario 1.1"/>
         <description value="Serve all current DocumentReference resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentReference"
             params="?status=current"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DocumentReference" count="3"/>
 

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-1-2-serve-0-documentreference.xml
@@ -14,10 +14,9 @@
         <name value="Scenario 1.2"/>
         <description
             value="Serve all current DocumentReference resources that are indexed/created in period from T-730 to T-365."/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentReference"
             params="?indexed=ge${DATE, T, D,-730}&amp;indexed=le${DATE, T, D,-365}&amp;status=current"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DocumentReference" count="0"/>
     </test>

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-1-4-serve-2-pdfa.xml
@@ -14,11 +14,10 @@
     <test id="scenario1-4-serve-DocumentReference">
         <name value="Scenario 1.4"/>
         <description value="Serve DocumentReference resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentReference"
             params="?status=current"
             responseId="documentreference-search-response"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <action>
             <assert>
                 <description

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-1-serve-1-documentreference.xml
@@ -11,10 +11,9 @@
     <test id="scenario2-1-serve-1-documentreference">
         <name value="Scenario 2.1"/>
         <description value="Serve all current DocumentReference resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentReference"
             params="?status=current"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DocumentReference" count="1"/>
         <action nts:in-targets="#default">

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-2-serve-2-documentmanifest.xml
@@ -11,10 +11,9 @@
     <test id="scenario2-2-serve-1-DocumentManifest">
         <name value="Scenario 2.2"/>
         <description value="Serve all current DocumentManifest resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentManifest"
             params="?status=current"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DocumentManifest" count="2"/>
         <nts:include value="assert.response.resourceWithLoinc"

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-3-serve-1-documentmanifest.xml
@@ -13,10 +13,9 @@
         <name value="Scenario 2.3"/>
         <description
             value="Serve all DocumentManifest resources of XXX-Schulte with a current status and created in the period from T-365 to T-60"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentManifest"
             params="?status=current&amp;created=ge${DATE, T, D,-365}&amp;created=le${DATE, T, D,-60}"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DocumentManifest" count="1"/>
     </test>

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-4-serve-1-documentreference.xml
@@ -24,11 +24,10 @@
         <name value="Scenario 2.4 - DocumentManifest"/>
         <description
             value="Serve DocumentManifest resource based on similiar request as scenario 2.3"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentManifest"
             params="?status=current&amp;created=ge${DATE, T, D,-365}&amp;created=le${DATE, T, D,-60}"
             responseId="documentmanifest-search-response"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <action>
             <assert>
                 <description

--- a/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa.xml
+++ b/src/PDFA-3-0/Cert/XIS-Server/medmij-pdfa-xis-2-5-serve-1-pdfa.xml
@@ -23,11 +23,10 @@
     <test id="scenario2-5-serve-DocumentReference">
         <name value="Scenario 2.5 - search DocumentReference"/>
         <description value="Serve DocumentReference resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="DocumentReference"
             params="?status=current"
             responseId="documentreference-search-response"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="DocumentReference" count="1"/>
         <nts:include value="assert.response.resourceWithLoinc" code="68626-1"/>

--- a/src/Questionnaires-2-0/Cert/_components/xis-scenario1-serveTask.xml
+++ b/src/Questionnaires-2-0/Cert/_components/xis-scenario1-serveTask.xml
@@ -23,6 +23,7 @@
         </operation>
     </action>
     <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
+    <nts:include value="assert.response.queryParamsInSelfLink" scope="common"/>
     <nts:include value="assert.response.numResources" scope="common">
         <nts:with-parameter name="resource" value="Task"/>
         <nts:with-parameter name="count" value="1"/>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-1-serve-all-bloodpressures.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-1-serve-all-bloodpressure">
         <name value="Scenario 1.1"/>
         <description value="Serve all BloodPressure Observation resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|85354-9"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="2"/>
     </test>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-2-serve-latest-bodyweight.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-2-serve-latest-bodyweight">
         <name value="Scenario 1.2"/>
         <description value="Serve latest bodyweight Observation resource"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="/$lastn?code=http://loinc.org|29463-7"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="1"/>
     </test>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-3-serve-all-bloodglucoses.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-3-serve-all-bloodglucose">
         <name value="Scenario 1.3"/>
         <description value="Serve all BloodGlucose Observation resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|14760-3,http://loinc.org|14743-9,http://loinc.org|14770-2"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="3"/>
     </test>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-4-serve-all-heartrates.xml
@@ -12,10 +12,9 @@
     <test id="scenario1-4-serve-all-heartrate">
         <name value="Scenario 1.4"/>
         <description value="Serve all HeartRate Observation resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|8867-4"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="2"/>
     </test>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-5-serve-period-bloodpressure.xml
@@ -13,10 +13,9 @@
     <test id="scenario1-5-serve-period-bloodpressure">
         <name value="Scenario 1.5"/>
         <description value="Serve BloodPressure Observation resources in a period"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|85354-9&amp;date=ge${DATE, T, D,-100}&amp;date=le${DATE, T, D,-50}"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="0"/>
     </test>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-6-serve-period-observations.xml
@@ -14,10 +14,9 @@
     <test id="scenario1-6-serve-period-observation">
         <name value="Scenario 1.6"/>
         <description value="Serve multiple type of Observation resources in period T-30 - T-0"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?code=http://loinc.org|85354-9,http://loinc.org|29463-7,http://loinc.org|14760-3,http://loinc.org|14743-9,http://loinc.org|14770-2,http://loinc.org|8867-4&amp;date=ge${DATE, T, D,-30}&amp;date=le${DATE, T, D,-0}"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="8"/>
     </test>

--- a/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns.xml
+++ b/src/SelfMeasurements-2-0/Cert/XIS-Server/selfmeasurements-xis-1-7-serve-all-vitalsigns.xml
@@ -13,10 +13,9 @@
     <test id="scenario1-7-serve-all-vitalsign-observation">
         <name value="Scenario 1.7"/>
         <description value="Serve all VitalSign Observation resources"/>
-        <nts:include value="medmij/test.xis.search" scope="common"
+        <nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Observation"
             params="?category=vital-signs"/>
-        <nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
         <nts:include value="assert.response.numResources" scope="common"
             resource="Observation" count="6"/>
     </test>

--- a/src/common-components/_assert.general.bundleContent.xml
+++ b/src/common-components/_assert.general.bundleContent.xml
@@ -16,5 +16,5 @@
             <warningOnly value="{$warningOnly}"/>
         </assert>
     </action>
-    <nts:include value="_assert.general.resourceContent" scope="common" resource="Bundle"/>
+    <nts:include value="_assert.general.resourceContent" scope="common" resourceBase="Bundle"/>
 </nts:component>

--- a/src/common-components/_assert.general.resourceContent.xml
+++ b/src/common-components/_assert.general.resourceContent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Generic asserts for resource content against FHIR core and the Nictiz FHIR IG.
-    @param resource - the resource type of which the contents are checked. 
+    @param resourceBase - the resource type of which the contents are checked. 
     @param direction - either "request" or "response".
     @param allowCodeWithoutSystem - If set, the resource is allowed to have a .code without a .system. The content of this variable doesn't actually matter.
 -->
@@ -11,21 +11,21 @@
         <assert>
             <description value="Confirm that all coding elements contain both a .system and a .code."/>
             <direction value="{$direction}"/>
-            <expression value="{$resource}.descendants().where($this.is(coding)).all(system.exists() and code.exists())"/>
+            <expression value="{$resourceBase}.descendants().where($this.is(coding)).all(system.exists() and code.exists())"/>
         </assert>
     </action>
     <action>
         <assert>
             <description value="Confirm that the OID of the zib valueset is not used for the system of a coding element."/>
             <direction value="{$direction}"/>
-            <expression value="{$resource}.descendants().where($this.is(coding)).system.startsWith('urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2').not()"/>
+            <expression value="{$resourceBase}.descendants().where($this.is(coding)).system.startsWith('urn:oid:2.16.840.1.113883.2.4.3.11.60.40.2').not()"/>
         </assert>
     </action>
     <action>
         <assert>
             <description value="Confirm that all CodeableConcept elements contain either a coding.display or a text value if no Coding exists or has an extension (e.g. a nullFlavor or data-absent-reason extension). For more information see https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_IG_STU3Use_of_coded_concepts."/>
             <direction value="{$direction}"/>
-            <expression value="{$resource}.descendants().where($this.is(CodeableConcept))
+            <expression value="{$resourceBase}.descendants().where($this.is(CodeableConcept))
                 .all(coding.display.exists() or text.exists() or extension.exists())"/>
         </assert>
     </action>
@@ -33,7 +33,7 @@
         <assert>
             <description value="Confirm that all References have a display value, see https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_IG_STU3#Use_of_the_reference_datatype."/>
             <direction value="{$direction}"/>
-            <expression value="{$resource}.descendants().where($this.is(Reference)).all(display.exists())"/>
+            <expression value="{$resourceBase}.descendants().where($this.is(Reference)).all(display.exists())"/>
         </assert>
     </action>
 </nts:component>

--- a/src/common-components/_reference/rules/assert_response_queryParamsInSelfLink.groovy
+++ b/src/common-components/_reference/rules/assert_response_queryParamsInSelfLink.groovy
@@ -1,0 +1,13 @@
+/*
+ rule.summary=Bundle.link.where(relation = 'self').url contains all parameters from the request URL
+ rule.description=Assert that the parameters in the request URL are all handled by the server by expecting the self link. 
+*/
+
+String[] urlParts = java.net.URLDecoder.decode(request.getURL()).split("\\?")
+if (urlParts.length > 0) {
+	String selfLink = java.net.URLDecoder.decode(response.getFhirPathValue("Bundle.link.where(relation = 'self').url"))
+	String requestParams = urlParts[1]
+	for (String param : requestParams.split('&')) {
+	    assert selfLink.contains(param) : "The request parameter \"" + param + "\" was absent from the self link." 
+	}
+}

--- a/src/common-components/assert.response.queryParamsInSelfLink.xml
+++ b/src/common-components/assert.response.queryParamsInSelfLink.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Assert that the parameters in the request URL of a search are all handled by the server by expecting the self link.
+   
+   This uses a rule in Groovy so that the parameters can simply be extracted from the search URL.
+-->
+<nts:component xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+    <nts:rule id="assert_response_queryParamsInSelfLink" href="rules/assert_response_queryParamsInSelfLink.groovy"/>
+    <action>
+        <assert nts:stopTestOnFail="false">
+            <rule>
+                <ruleId value="assert_response_queryParamsInSelfLink"/>
+            </rule>
+            <warningOnly value="true"/>
+        </assert>
+    </action>
+</nts:component>
+

--- a/src/common-components/assert.response.success.xml
+++ b/src/common-components/assert.response.success.xml
@@ -5,7 +5,7 @@
 <nts:component xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert nts:stopTestOnFail="true">
-            <description value="Confirm that the operation was succesful"/>
+            <description value="Confirm that the operation was successful"/>
             <operator value="in"/>
             <responseCode value="200,201"/>
         </assert>

--- a/src/common-components/assert.response.successfulSearch.xml
+++ b/src/common-components/assert.response.successfulSearch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Check that a server responds correctly to a succesful search.
+    Check that a server responds correctly to a successful search.
     @param allowCodeWithoutSystem - If set, the resource is allowed to have a .code without a .system. The content of this variable doesn't actually matter.
 -->
 <nts:component xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">

--- a/src/common-components/medmij/test.xis.successfulRead.xml
+++ b/src/common-components/medmij/test.xis.successfulRead.xml
@@ -9,6 +9,6 @@
 <nts:component xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <nts:include value="medmij/test.xis.read" scope="common"/>
     <nts:include value="assert.response.success" scope="common"/>
-    <nts:include value="_assert.general.resourceContent" scope="common" resource="{$resource}" direction="response"/>
+    <nts:include value="_assert.general.resourceContent" scope="common" resourceBase="{$resource}" direction="response"/>
 </nts:component>
 

--- a/src/common-components/medmij/test.xis.successfulSearch.xml
+++ b/src/common-components/medmij/test.xis.successfulSearch.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    XIS test to search for a successful search on a specific resource, to be added to `TestScript.test`. It is expected
+    that the "patient-token-id" variable is set.
+    @param resource - The resource to search for.
+    @param [params] - Optional, the "params" string to add to the search.
+    @param [description] - An optional description for the operation. If omitted, a description will be auto-generated.
+    @param [responseId] - An optional id to cache the response.
+-->
+<nts:component xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+    <action>
+        <operation>
+            <type>
+                <system value="http://hl7.org/fhir/testscript-operation-codes"/>
+                <code value="search"/>
+            </type>
+            <resource value="{$resource}"/>
+            <description nts:ifnotset="description" value="Test XIS server to serve {$resource} resources."/>
+            <description nts:ifset="description" value="{$description}"/>
+            <destination value="1"/>
+            <origin value="1"/>
+            <params nts:ifset="params" value="{$params}"/>
+            <nts:include value="header.request.PatientToken" scope="common"/>
+            <nts:include value="medmij/header.request.MedMijRequestId" scope="common"/>
+            <responseId nts:ifset="responseId" value="{$responseId}"/>
+        </operation>
+    </action>
+    <nts:include value="medmij/assert.response.successfulSearch" scope="common" resource="Bundle"/>
+    <nts:include nts:ifset="params" value="assert.response.queryParamsInSelfLink" scope="common"/>
+</nts:component>

--- a/src/eAppointment-2-0/Cert/XIS-Server/medmij-eappt-xis-1-1-serve-future.xml
+++ b/src/eAppointment-2-0/Cert/XIS-Server/medmij-eappt-xis-1-1-serve-future.xml
@@ -14,10 +14,9 @@
 		<name value="Scenario 1.1"/>
 		<description
 			value="Serve Appointment resources of XXX-Verweij in a period from T-150 and everything in the future."/>
-		<nts:include value="medmij/test.xis.search" scope="common"
+		<nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Appointment"
             params="?date=ge${DATE, T, D,-150}"/>
-		<nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
 		<nts:include value="assert.response.numResources" scope="common"
             resource="Appointment" count="3"/>
 	</test>

--- a/src/eAppointment-2-0/Cert/XIS-Server/medmij-eappt-xis-1-2-serve-month.xml
+++ b/src/eAppointment-2-0/Cert/XIS-Server/medmij-eappt-xis-1-2-serve-month.xml
@@ -14,10 +14,9 @@
 	<test id="01-serve-appointment">
 		<name value="Scenario 1.2"/>
 		<description value="Serve Appointment resources of XXX-Zalentein in a one month period"/>
-		<nts:include value="medmij/test.xis.search" scope="common"
+		<nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Appointment"
             params="?date=ge${DATE, T, D,-30}&amp;date=le${DATE, T, D,-0}"/>
-		<nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
 		<nts:include value="assert.response.numResources" scope="common"
             resource="Appointment" count="2"/>
 	</test>

--- a/src/eAppointment-2-0/Cert/XIS-Server/medmij-eappt-xis-1-3-serve-year.xml
+++ b/src/eAppointment-2-0/Cert/XIS-Server/medmij-eappt-xis-1-3-serve-year.xml
@@ -14,10 +14,9 @@
 	<test id="01-serve-appointment">
 		<name value="Scenario 1.3"/>
 		<description value="Serve Appointment resources of XXX-Egmond in a one year period"/>
-		<nts:include value="medmij/test.xis.search" scope="common"
+		<nts:include value="medmij/test.xis.successfulSearch" scope="common"
             resource="Appointment"
             params="?date=ge${DATE, T, D,-365}&amp;date=le${DATE, T, D,-0}"/>
-		<nts:include value="medmij/assert.response.successfulSearch" scope="common"/>
 		<nts:include value="assert.response.noEntries" scope="common"/>
 	</test>
 </TestScript>


### PR DESCRIPTION
Note: this only works in combination with the fix in https://github.com/Nictiz/Nictiz-tooling-testscripts/pull/16